### PR TITLE
model 1 observers

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -1,4 +1,5 @@
 from vivarium_gates_nutrition_optimization_child.components.causes import (
+    RiskAttributableDisease,
     SIS_with_birth_prevalence,
 )
 from vivarium_gates_nutrition_optimization_child.components.fertility import (
@@ -10,12 +11,12 @@ from vivarium_gates_nutrition_optimization_child.components.maternal_characteris
     BirthWeightShiftEffect,
     MaternalCharacteristics,
 )
-
-# from vivarium_gates_nutrition_optimization_child.components.observers import (
-#     BirthObserver,
-#     DisabilityObserver,
-#     ResultsStratifier,
-# )
+from vivarium_gates_nutrition_optimization_child.components.observers import (
+    BirthObserver,
+    DisabilityObserver,
+    MortalityObserver,
+    ResultsStratifier,
+)
 from vivarium_gates_nutrition_optimization_child.components.population import (
     PopulationLineList,
 )

--- a/src/vivarium_gates_nutrition_optimization_child/components/causes.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/causes.py
@@ -2,7 +2,12 @@
 Component to include birth prevalence in SIS model.
 """
 
-from vivarium_public_health.disease import DiseaseModel, DiseaseState, SusceptibleState
+from vivarium.framework.state_machine import State
+from vivarium_public_health.disease import DiseaseModel, DiseaseState
+from vivarium_public_health.disease import (
+    RiskAttributableDisease as RiskAttributableDisease_,
+)
+from vivarium_public_health.disease import SusceptibleState
 
 
 def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
@@ -21,3 +26,11 @@ def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
     infected.add_transition(healthy, source_data_type="rate")
 
     return DiseaseModel(cause, states=[healthy, infected])
+
+
+class RiskAttributableDisease(RiskAttributableDisease_):
+    """This class has the states attribute so it works with the VPH disease observer"""
+
+    def __init__(self, cause, risk):
+        super().__init__(cause, risk)
+        self.states = [State(state_name) for state_name in self.state_names]

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -77,7 +77,7 @@ class ResultsStratifier(ResultsStratifier_):
             "cat2": data_keys.CGFCategories.MODERATE.value,
             "cat1": data_keys.CGFCategories.SEVERE.value,
         }
-        return pop.squeeze(axis=1).replace(mapper)
+        return pop.squeeze(axis=1).map(mapper)
 
     def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:
         """Map age with age group name strings
@@ -154,6 +154,7 @@ class BirthObserver:
 
         builder.results.register_observation(
             name=f"live_births",
+            pop_filter="alive=='alive'",
             aggregator=self.count_live_births,
             requires_columns=["entrance_time"],
             additional_stratifications=self.config.include,
@@ -162,6 +163,7 @@ class BirthObserver:
         )
         builder.results.register_observation(
             name=f"birth_weight_sum",
+            pop_filter="alive=='alive'",
             aggregator=self.sum_birth_weights,
             requires_columns=["entrance_time", self.birth_weight_column_name],
             additional_stratifications=self.config.include,
@@ -170,6 +172,7 @@ class BirthObserver:
         )
         builder.results.register_observation(
             name=f"gestational_age_sum",
+            pop_filter="alive=='alive'",
             aggregator=self.sum_gestational_ages,
             requires_columns=["entrance_time", self.gestational_age_column_name],
             additional_stratifications=self.config.include,
@@ -178,6 +181,7 @@ class BirthObserver:
         )
         builder.results.register_observation(
             name=f"low_weight_births",
+            pop_filter="alive=='alive'",
             aggregator=self.count_low_weight_births,
             requires_columns=["entrance_time", self.birth_weight_column_name],
             additional_stratifications=self.config.include,

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -9,77 +9,96 @@ from vivarium.framework.population import PopulationView
 from vivarium_public_health.metrics.disability import (
     DisabilityObserver as DisabilityObserver_,
 )
+from vivarium_public_health.metrics.mortality import (
+    MortalityObserver as MortalityObserver_,
+)
 from vivarium_public_health.metrics.stratification import (
     ResultsStratifier as ResultsStratifier_,
 )
 
-from vivarium_gates_nutrition_optimization_child.constants import data_keys
-
-# from vivarium_public_health.metrics.stratification import Source, SourceType
+from vivarium_gates_nutrition_optimization_child.constants import data_keys, results
 
 
-# class ResultsStratifier(ResultsStratifier_):
-#     """Centralized component for handling results stratification.
-#     This should be used as a sub-component for observers.  The observers
-#     can then ask this component for population subgroups and labels during
-#     results production and have this component manage adjustments to the
-#     final column labels for the subgroups.
-#     """
-#
-#     def register_stratifications(self, builder: Builder) -> None:
-#         """Register each desired stratification with calls to _setup_stratification"""
-#         super().register_stratifications(builder)
-#
-#         self.setup_stratification(
-#             builder,
-#             name="wasting_state",
-#             sources=[Source(f"{data_keys.WASTING.name}.exposure", SourceType.PIPELINE)],
-#             categories={category.value for category in data_keys.CGFCategories},
-#             mapper=self.child_growth_risk_factor_stratification_mapper,
-#         )
-#
-#         self.setup_stratification(
-#             builder,
-#             name="stunting_state",
-#             sources=[Source(f"{data_keys.STUNTING.name}.exposure", SourceType.PIPELINE)],
-#             categories={category.value for category in data_keys.CGFCategories},
-#             mapper=self.child_growth_risk_factor_stratification_mapper,
-#         )
-#
-#         self.setup_stratification(
-#             builder,
-#             name="maternal_supplementation",
-#             sources=[Source("maternal_supplementation_exposure", SourceType.COLUMN)],
-#             categories={"uncovered", "ifa", "mms", "bep"},
-#         )
-#
-#         self.setup_stratification(
-#             builder,
-#             name="iv_iron",
-#             sources=[Source("iv_iron_exposure", SourceType.COLUMN)],
-#             categories={"uncovered", "covered"},
-#         )
-#
-#         self.setup_stratification(
-#             builder,
-#             name="bmi_anemia",
-#             sources=[Source("maternal_bmi_anemia_exposure", SourceType.COLUMN)],
-#             categories={"cat4", "cat3", "cat2", "cat1"},
-#         )
-#
-#     ###########################
-#     # Stratifications Details #
-#     ###########################
-#
-#     # noinspection PyMethodMayBeStatic
-#     def child_growth_risk_factor_stratification_mapper(self, row: pd.Series) -> str:
-#         # applicable to stunting and wasting
-#         return {
-#             "cat4": data_keys.CGFCategories.UNEXPOSED.value,
-#             "cat3": data_keys.CGFCategories.MILD.value,
-#             "cat2": data_keys.CGFCategories.MODERATE.value,
-#             "cat1": data_keys.CGFCategories.SEVERE.value,
-#         }[row.squeeze()]
+class ResultsStratifier(ResultsStratifier_):
+    """Centralized component for handling results stratification.
+    This should be used as a sub-component for observers.  The observers
+    can then ask this component for population subgroups and labels during
+    results production and have this component manage adjustments to the
+    final column labels for the subgroups.
+    """
+
+    def register_stratifications(self, builder: Builder) -> None:
+        """Register each desired stratification with calls to _setup_stratification"""
+        super().register_stratifications(builder)
+
+        builder.results.register_stratification(
+            "wasting_state",
+            [category.value for category in data_keys.CGFCategories],
+            self.child_growth_risk_factor_stratification_mapper,
+            is_vectorized=True,
+            requires_values=["child_wasting.exposure"],
+        )
+        builder.results.register_stratification(
+            "stunting_state",
+            [category.value for category in data_keys.CGFCategories],
+            self.child_growth_risk_factor_stratification_mapper,
+            is_vectorized=True,
+            requires_values=["child_stunting.exposure"],
+        )
+        builder.results.register_stratification(
+            "maternal_supplementation",
+            results.MATERNAL_SUPPLEMENTATION_TYPES,
+            is_vectorized=True,
+            requires_columns=["maternal_supplementation_exposure"],
+        )
+        builder.results.register_stratification(
+            "iv_iron",
+            results.DICHOTOMOUS_COVERAGE_STATES,
+            is_vectorized=True,
+            requires_columns=["iv_iron_exposure"],
+        )
+        builder.results.register_stratification(
+            "bmi_anemia",
+            ["cat4", "cat3", "cat2", "cat1"],
+            is_vectorized=True,
+            requires_columns=["maternal_bmi_anemia_exposure"],
+        )
+
+    ###########################
+    # Stratifications Details #
+    ###########################
+
+    # noinspection PyMethodMayBeStatic
+    def child_growth_risk_factor_stratification_mapper(self, pop: pd.DataFrame) -> pd.Series:
+        # applicable to stunting and wasting
+        mapper = {
+            "cat4": data_keys.CGFCategories.UNEXPOSED.value,
+            "cat3": data_keys.CGFCategories.MILD.value,
+            "cat2": data_keys.CGFCategories.MODERATE.value,
+            "cat1": data_keys.CGFCategories.SEVERE.value,
+        }
+        return pop.squeeze(axis=1).replace(mapper)
+
+    def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:
+        """Map age with age group name strings
+
+        Parameters
+        ----------
+        pop
+            A DataFrame with one column, an age to be mapped to an age group name string
+
+        Returns
+        ------
+        pandas.Series
+            A pd.Series with age group name string corresponding to the pop passed into the function
+        """
+        bins = self.age_bins["age_start"].to_list() + [self.age_bins["age_end"].iloc[-1]]
+        labels = self.age_bins["age_group_name"].to_list()
+        # need to include lowest to map people who are exactly 0
+        age_group = pd.cut(
+            pop.squeeze(axis=1), bins, labels=labels, include_lowest=True
+        ).rename("age_group")
+        return age_group
 
 
 class DisabilityObserver(DisabilityObserver_):
@@ -92,111 +111,102 @@ class DisabilityObserver(DisabilityObserver_):
                 self.disability_pipelines[cause.state_id] = cause.disability_weight
 
 
-# class BirthObserver:
-#
-#     configuration_defaults = {
-#         "observers": {
-#             "birth": {
-#                 "exclude": [],
-#                 "include": [],
-#             }
-#         }
-#     }
-#
-#     metrics_pipeline_name = "metrics"
-#
-#     birth_weight_column_name = "birth_weight_exposure"
-#     gestational_age_column_name = "gestational_age_exposure"
-#     columns_required = [
-#         "entrance_time",
-#         birth_weight_column_name,
-#         gestational_age_column_name,
-#     ]
-#
-#     low_birth_weight_limit = 2500  # grams
-#
-#     def __repr__(self):
-#         return "BirthObserver()"
-#
-#     ##############
-#     # Properties #
-#     ##############
-#
-#     @property
-#     def name(self):
-#         return "birth_observer"
-#
-#     #################
-#     # Setup methods #
-#     #################
-#
-#     # noinspection PyAttributeOutsideInit
-#     def setup(self, builder: Builder) -> None:
-#         self.config = self._get_stratification_configuration(builder)
-#         self.stratifier = self._get_stratifier(builder)
-#         self.population_view = self._get_population_view(builder)
-#
-#         self.counts = Counter()
-#
-#         self._register_collect_metrics_listener(builder)
-#         self._register_metrics_modifier(builder)
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
-#         return builder.configuration.observers.birth
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
-#         return builder.components.get_component(ResultsStratifier.name)
-#
-#     def _get_population_view(self, builder: Builder) -> PopulationView:
-#         return builder.population.get_view(self.columns_required)
-#
-#     def _register_collect_metrics_listener(self, builder: Builder) -> None:
-#         builder.event.register_listener("collect_metrics", self.on_collect_metrics)
-#
-#     def _register_metrics_modifier(self, builder: Builder) -> None:
-#         builder.value.register_value_modifier(
-#             self.metrics_pipeline_name,
-#             modifier=self.metrics,
-#             requires_columns=["age", "exit_time", "alive"],
-#         )
-#
-#     ########################
-#     # Event-driven methods #
-#     ########################
-#
-#     def on_collect_metrics(self, event: Event) -> None:
-#         pop = self.population_view.get(event.index)
-#         pop_born = pop[pop["entrance_time"] == event.time - event.step_size]
-#
-#         if pop_born.empty:
-#             return
-#         groups = self.stratifier.group(
-#             pop_born.index, self.config.include, self.config.exclude
-#         )
-#         for label, group_mask in groups:
-#             pop_born_in_group = pop_born[group_mask]
-#             low_birth_weight_mask = (
-#                 pop_born_in_group[self.birth_weight_column_name] < self.low_birth_weight_limit
-#             )
-#             new_observations = {
-#                 f"live_births_{label}": pop_born_in_group.index.size,
-#                 f"birth_weight_sum_{label}": pop_born_in_group[
-#                     self.birth_weight_column_name
-#                 ].sum(),
-#                 f"gestational_age_sum_{label}": pop_born_in_group[
-#                     self.gestational_age_column_name
-#                 ].sum(),
-#                 f"low_weight_births_{label}": low_birth_weight_mask.sum(),
-#             }
-#             self.counts.update(new_observations)
-#
-#     ##################################
-#     # Pipeline sources and modifiers #
-#     ##################################
-#
-#     def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
-#         metrics.update(self.counts)
-#
-#         return metrics
+class BirthObserver:
+
+    configuration_defaults = {
+        "stratification": {
+            "birth": {
+                "exclude": [],
+                "include": [],
+            }
+        }
+    }
+
+    def __repr__(self):
+        return "BirthObserver()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "birth_observer"
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.clock = builder.time.clock()
+        self.config = builder.configuration.stratification.birth
+        self.birth_weight_column_name = "birth_weight_exposure"
+        self.gestational_age_column_name = "gestational_age_exposure"
+        self.low_birth_weight_limit = 2500  # grams
+
+        columns_required = [
+            "entrance_time",
+            self.birth_weight_column_name,
+            self.gestational_age_column_name,
+        ]
+        self.population_view = builder.population.get_view(columns_required)
+
+        builder.results.register_observation(
+            name=f"live_births",
+            aggregator=self.count_live_births,
+            requires_columns=["entrance_time"],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+        builder.results.register_observation(
+            name=f"birth_weight_sum",
+            aggregator=self.sum_birth_weights,
+            requires_columns=["entrance_time", self.birth_weight_column_name],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+        builder.results.register_observation(
+            name=f"gestational_age_sum",
+            aggregator=self.sum_gestational_ages,
+            requires_columns=["entrance_time", self.gestational_age_column_name],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+        builder.results.register_observation(
+            name=f"low_weight_births",
+            aggregator=self.count_low_weight_births,
+            requires_columns=["entrance_time", self.birth_weight_column_name],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
+
+    ########################
+    # Event-driven methods #
+    ########################
+    def count_live_births(self, x: pd.DataFrame) -> float:
+        born_this_step = x["entrance_time"] == self.clock()
+        return sum(born_this_step)
+
+    def sum_birth_weights(self, x: pd.DataFrame) -> float:
+        born_this_step = x["entrance_time"] == self.clock()
+        return x.loc[born_this_step, self.birth_weight_column_name].sum()
+
+    def sum_gestational_ages(self, x: pd.DataFrame) -> float:
+        born_this_step = x["entrance_time"] == self.clock()
+        return x.loc[born_this_step, self.gestational_age_column_name].sum()
+
+    def count_low_weight_births(self, x: pd.DataFrame) -> float:
+        born_this_step = x["entrance_time"] == self.clock()
+        has_low_birth_weight = (
+            x.loc[born_this_step, self.birth_weight_column_name] < self.low_birth_weight_limit
+        )
+        return sum(has_low_birth_weight)
+
+
+class MortalityObserver(MortalityObserver_):
+    """This is a class to make component ordering work in the model spec."""

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -1,4 +1,3 @@
-
 components:
     vivarium_public_health:
         population:
@@ -6,8 +5,6 @@ components:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
-            - RiskAttributableDisease('cause.moderate_protein_energy_malnutrition', 'risk_factor.child_wasting')
-            - RiskAttributableDisease('cause.severe_protein_energy_malnutrition', 'risk_factor.child_wasting')
         risks:
             - Risk('risk_factor.child_wasting')
             - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
@@ -22,24 +19,22 @@ components:
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-#        metrics:
-#            - MortalityObserver()
-#            - DiseaseObserver('diarrheal_diseases')
-#            - DiseaseObserver('measles')
-#            - DiseaseObserver('lower_respiratory_infections')
-#            - DiseaseObserver('moderate_protein_energy_malnutrition')
-#            - DiseaseObserver('severe_protein_energy_malnutrition')
-#            - CategoricalRiskObserver('child_stunting')
-#            - CategoricalRiskObserver('child_wasting')
+        metrics:
+            - DiseaseObserver('diarrheal_diseases')
+            - DiseaseObserver('measles')
+            - DiseaseObserver('lower_respiratory_infections')
+            - DiseaseObserver('moderate_protein_energy_malnutrition')
+            - DiseaseObserver('severe_protein_energy_malnutrition')
+            - CategoricalRiskObserver('child_stunting')
+            - CategoricalRiskObserver('child_wasting')
 
     vivarium_gates_nutrition_optimization_child:
         components:
             - PopulationLineList()
             - FertilityLineList()
             - LBWSGLineList()
-#            - ResultsStratifier()
-#            - BirthObserver()
-#            - DisabilityObserver()
+            - BirthObserver()
+            - DisabilityObserver()
 
             - MaternalCharacteristics()
             - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
@@ -49,6 +44,10 @@ components:
             - AdditiveRiskEffect('risk_factor.maternal_bmi_anemia', 'risk_factor.birth_weight.birth_exposure')
             - BirthWeightShiftEffect()
             - SIS_with_birth_prevalence('diarrheal_diseases')
+            - RiskAttributableDisease('cause.moderate_protein_energy_malnutrition', 'risk_factor.child_wasting')
+            - RiskAttributableDisease('cause.severe_protein_energy_malnutrition', 'risk_factor.child_wasting')
+            - MortalityObserver()
+            - ResultsStratifier()
 
 configuration:
     input_data:
@@ -106,11 +105,11 @@ configuration:
         mortality: True
         recoverable: True
 
-    observers:
+    stratification:
         default:
-            - "year"
+            - "current_year"
             - "sex"
-            - "age"
+            - "age_group"
         child_stunting:
             include:
                 - "maternal_supplementation"
@@ -121,7 +120,7 @@ configuration:
                 - "iv_iron"
         birth:
             exclude:
-                - "age"
+                - "age_group"
             include:
                 - "maternal_supplementation"
                 - "iv_iron"


### PR DESCRIPTION
## model 1 observers

### Description
- *Category*: observers
- *JIRA issue*: [MIC-4323](https://jira.ihme.washington.edu/browse/MIC-4323)
- *Research reference*: [Model 1 Run](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.html#wave-i)

### Changes and notes
Subclass RiskAttributableDisease to have states attribute for disease observer.
Subclass MortalityObserver so it can be defined in model spec and setup after all disease components. 
Update stratification registration and child growth failure stratification mapper in results stratifier. Redefine age groups mapper to be left interval inclusive.
Rewrite birth observer.

### Verification and Testing
Ran simulation for a few time steps and checked that we saw expecteda observations and stratifications. Cursory run through to make sure values were somewhat reasonable. 