### PR TITLE
initialize stillbirths 

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -8,6 +8,7 @@ Fertility module to create simulants from existing data
 """
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
@@ -39,7 +40,10 @@ class FertilityLineList:
         # Requirements for input data
         self.birth_records = self._get_birth_records(builder)
 
+        self.population_view = builder.population.get_view(["alive", "cause_of_death"])
+
         builder.event.register_listener("time_step", self.on_time_step)
+        builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
 
     @staticmethod
     def _get_birth_records(builder: Builder) -> pd.DataFrame:
@@ -69,7 +73,18 @@ class FertilityLineList:
         )
         # TODO: remove resetting index when using actual child data
         born_previous_step = birth_records[born_previous_step_mask].reset_index().copy()
+        # everyone is currently born on the first time step so this is always empty after the first time step
+        if born_previous_step.empty:
+            return
         born_previous_step.loc[:, "maternal_id"] = born_previous_step.index
+        # stillbirths should be initialized as dead and with exit time
+        born_previous_step.loc[:, "alive"] = 'alive'
+        born_previous_step.loc[:, "exit_time"] = np.datetime64('NaT')
+
+        is_stillbirth = born_previous_step['pregnancy_outcome'] == 'stillbirth'
+        born_previous_step.loc[is_stillbirth, "alive"] = 'dead'
+        born_previous_step.loc[is_stillbirth, "exit_time"] = self.clock()
+
         simulants_to_add = len(born_previous_step)
 
         if simulants_to_add > 0:
@@ -82,3 +97,10 @@ class FertilityLineList:
                     "new_births": born_previous_step,
                 },
             )
+
+    def on_time_step_cleanup(self, event: Event) -> None:
+        # update cause_of_death on cleanup because mortality handles that column on initialization
+        pop = self.population_view.get(event.index)
+        is_stillborn = (pop['alive'] == 'dead') & (pop['cause_of_death'] == 'not_dead')
+        pop.loc[is_stillborn,'cause_of_death'] = 'stillborn'
+        self.population_view.update(pop)

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -78,11 +78,11 @@ class FertilityLineList:
             return
         born_previous_step.loc[:, "maternal_id"] = born_previous_step.index
         # stillbirths should be initialized as dead and with exit time
-        born_previous_step.loc[:, "alive"] = 'alive'
-        born_previous_step.loc[:, "exit_time"] = np.datetime64('NaT')
+        born_previous_step.loc[:, "alive"] = "alive"
+        born_previous_step.loc[:, "exit_time"] = np.datetime64("NaT")
 
-        is_stillbirth = born_previous_step['pregnancy_outcome'] == 'stillbirth'
-        born_previous_step.loc[is_stillbirth, "alive"] = 'dead'
+        is_stillbirth = born_previous_step["pregnancy_outcome"] == "stillbirth"
+        born_previous_step.loc[is_stillbirth, "alive"] = "dead"
         born_previous_step.loc[is_stillbirth, "exit_time"] = self.clock()
 
         simulants_to_add = len(born_previous_step)
@@ -101,6 +101,6 @@ class FertilityLineList:
     def on_time_step_cleanup(self, event: Event) -> None:
         # update cause_of_death on cleanup because mortality handles that column on initialization
         pop = self.population_view.get(event.index)
-        is_stillborn = (pop['alive'] == 'dead') & (pop['cause_of_death'] == 'not_dead')
-        pop.loc[is_stillborn,'cause_of_death'] = 'stillborn'
+        is_stillborn = (pop["alive"] == "dead") & (pop["cause_of_death"] == "not_dead")
+        pop.loc[is_stillborn, "cause_of_death"] = "stillborn"
         self.population_view.update(pop)

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -104,10 +104,10 @@ class PopulationLineList(BasePopulation):
             # Create columns for state table
             new_simulants["age"] = 0.0
             new_simulants["sex"] = new_births["sex"]
-            new_simulants["alive"] = "alive"
+            new_simulants["alive"] = new_births["alive"]
             new_simulants["location"] = self.location
             new_simulants["entrance_time"] = pop_data.creation_time
-            new_simulants["exit_time"] = pd.NaT
+            new_simulants["exit_time"] = new_births['exit_time']
             new_simulants["maternal_id"] = new_births["maternal_id"]
 
         self.register_simulants(new_simulants[self.key_columns])

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -107,7 +107,7 @@ class PopulationLineList(BasePopulation):
             new_simulants["alive"] = new_births["alive"]
             new_simulants["location"] = self.location
             new_simulants["entrance_time"] = pop_data.creation_time
-            new_simulants["exit_time"] = new_births['exit_time']
+            new_simulants["exit_time"] = new_births["exit_time"]
             new_simulants["maternal_id"] = new_births["maternal_id"]
 
         self.register_simulants(new_simulants[self.key_columns])

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -53,9 +53,11 @@ configuration:
     input_data:
         input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/ethiopia.hdf'
+        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/ethiopia.hdf'
+        artifact_path: '/home/hussain-jafari/artifacts/nutrition/ethiopia.hdf'
         # FIXME: Won't work commented out so replace with child_data folder created by IV iron maternal model
-        fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/vivarium_gates_nutrition_optimization_child/data/test_data/child_data'
+        #fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/vivarium_gates_nutrition_optimization_child/data/test_data/child_data'
+        fertility_input_data_path: '/home/hussain-jafari/artifacts/nutrition/child_data/'
     interpolation:
         order: 0
         extrapolate: True
@@ -69,9 +71,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2041
+            year: 2019
             month: 1
-            day: 1
+            day: 6
         step_size: 4 # Days
     population:
         population_size: 0

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -53,11 +53,9 @@ configuration:
     input_data:
         input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
-        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/ethiopia.hdf'
-        artifact_path: '/home/hussain-jafari/artifacts/nutrition/ethiopia.hdf'
+        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/ethiopia.hdf'
         # FIXME: Won't work commented out so replace with child_data folder created by IV iron maternal model
-        #fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/vivarium_gates_nutrition_optimization_child/data/test_data/child_data'
-        fertility_input_data_path: '/home/hussain-jafari/artifacts/nutrition/child_data/'
+        fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/vivarium_gates_nutrition_optimization_child/data/test_data/child_data'
     interpolation:
         order: 0
         extrapolate: True
@@ -71,9 +69,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2019
+            year: 2041
             month: 1
-            day: 6
+            day: 1
         step_size: 4 # Days
     population:
         population_size: 0


### PR DESCRIPTION
## initialize stillbirths

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4389](https://jira.ihme.washington.edu/browse/MIC-4389)

### Changes and notes
We need to include stillbirth information into our births. Initialize stillbirths as dead and update their exit time and cause of death to 'stillbirth'. I wasn't able to update tracked to False because the results stratifier would try to stratify the population by wasting exposure but would pull untracked simulants who had NaN exposures. 

### Verification and Testing
Looked at outputs across multiple time steps to check that we were observing deaths, YLLs, and birth information as expected.