### PR TITLE
add all transitions to PEM component

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/causes.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/causes.py
@@ -8,6 +8,7 @@ from vivarium_public_health.disease import (
     RiskAttributableDisease as RiskAttributableDisease_,
 )
 from vivarium_public_health.disease import SusceptibleState
+from vivarium_public_health.disease.transition import TransitionString
 
 
 def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
@@ -29,8 +30,15 @@ def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
 
 
 class RiskAttributableDisease(RiskAttributableDisease_):
-    """This class has the states attribute so it works with the VPH disease observer"""
+    """This class has the states attribute so it works with the VPH disease observer
+    and adds the infected to susceptible transition in the __init__ so the disease observer
+    registers this transition during its setup."""
 
     def __init__(self, cause, risk):
         super().__init__(cause, risk)
         self.states = [State(state_name) for state_name in self.state_names]
+        self._transition_names.append(TransitionString(f"{self.cause.name}_TO_susceptible_to_{self.cause.name}"))
+
+    def adjust_state_and_transitions(self):
+        # we would normally add the transition here which is no longer required
+        pass

--- a/src/vivarium_gates_nutrition_optimization_child/components/causes.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/causes.py
@@ -37,7 +37,9 @@ class RiskAttributableDisease(RiskAttributableDisease_):
     def __init__(self, cause, risk):
         super().__init__(cause, risk)
         self.states = [State(state_name) for state_name in self.state_names]
-        self._transition_names.append(TransitionString(f"{self.cause.name}_TO_susceptible_to_{self.cause.name}"))
+        self._transition_names.append(
+            TransitionString(f"{self.cause.name}_TO_susceptible_to_{self.cause.name}")
+        )
 
     def adjust_state_and_transitions(self):
         # we would normally add the transition here which is no longer required


### PR DESCRIPTION
## add all transitions to PEM component

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4403](https://jira.ihme.washington.edu/browse/MIC-4403)

### Changes and notes
In a RiskAttributableDisease, the infected to susceptible transition is added to the transition names attribute on setup. The DiseaseObserver registers these transition observations in its setup which occurs before PEM's so it never gets registered. Add this transition on instantiation instead.  

### Verification and Testing
Ran a sim for a few steps and saw these observation transitions in the output.