### PR TITLE
model 8.0.1 update bep effect

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -8,6 +8,7 @@ from vivarium_gates_nutrition_optimization_child.components.fertility import (
 from vivarium_gates_nutrition_optimization_child.components.lbwsg import LBWSGLineList
 from vivarium_gates_nutrition_optimization_child.components.maternal_characteristics import (
     AdditiveRiskEffect,
+    BEPEffectOnBirthweight,
     BirthWeightShiftEffect,
     MaternalCharacteristics,
     MMSEffectOnGestationalAge,

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -372,12 +372,6 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
     def __init__(self):
         super().__init__('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
 
-    def setup(self, builder: Builder) -> None:
-        super().setup(builder)
-        self.excess_shift_source = self._get_excess_shift_source(builder)
-        self.risk_specific_shift_source = self._get_risk_specific_shift_source(builder)
-        self.population_view = builder.population.get_view(['maternal_bmi_anemia_exposure'])
-
     def _get_excess_shift_source(self, builder: Builder) -> LookupTable:
         excess_shift_data = builder.data.load(
             f"{self.risk}.excess_shift",
@@ -390,7 +384,6 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
             excess_shift_data, key_columns=["sex", "maternal_bmi_anemia_exposure"], parameter_columns=["age", "year"]
         )
 
-
     def _pivot_categorical(self, data: pd.DataFrame) -> pd.DataFrame:
         """Pivots data that is long on categories to be wide.
         Copied from VPH but include maternal BMI anemia exposure."""
@@ -399,27 +392,6 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
         data = data.pivot_table(index=key_cols, columns="parameter", values="value").reset_index()
         data.columns.name = None
         return data
-
-
-    def get_effect(self, index: pd.Index) -> pd.Series:
-        index_columns = ["index", self.risk.name]
-
-        excess_shift = self.excess_shift_source(index)
-        pop = self.population_view.get(index)
-        breakpoint()
-        exposure = self.exposure(index).reset_index()
-        exposure.columns = index_columns
-        exposure = exposure.set_index(index_columns)
-
-        relative_risk = excess_shift.stack().reset_index()
-        relative_risk.columns = index_columns + ["value"]
-        relative_risk = relative_risk.set_index(index_columns)
-
-        raw_effect = relative_risk.loc[exposure.index, "value"].droplevel(self.risk.name)
-
-        risk_specific_shift = self.risk_specific_shift_source(index)
-        effect = raw_effect - risk_specific_shift
-        return effect
 
 
 class BirthWeightShiftEffect:

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -367,10 +367,14 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
 
 
 class BEPEffectOnBirthweight(AdditiveRiskEffect):
-    '''Model effect of BEP on birthweight. Unique component because effect of BEP depends
-    on mother's BMI status.'''
+    """Model effect of BEP on birthweight. Unique component because effect of BEP depends
+    on mother's BMI status."""
+
     def __init__(self):
-        super().__init__('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
+        super().__init__(
+            "risk_factor.balanced_energy_protein_supplementation",
+            "risk_factor.birth_weight.birth_exposure",
+        )
 
     def _get_excess_shift_source(self, builder: Builder) -> LookupTable:
         excess_shift_data = builder.data.load(
@@ -381,15 +385,26 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
         excess_shift_data = rebin_relative_risk_data(builder, self.risk, excess_shift_data)
         excess_shift_data = self._pivot_categorical(excess_shift_data)
         return builder.lookup.build_table(
-            excess_shift_data, key_columns=["sex", "maternal_bmi_anemia_exposure"], parameter_columns=["age", "year"]
+            excess_shift_data,
+            key_columns=["sex", "maternal_bmi_anemia_exposure"],
+            parameter_columns=["age", "year"],
         )
 
     def _pivot_categorical(self, data: pd.DataFrame) -> pd.DataFrame:
         """Pivots data that is long on categories to be wide.
         Copied from VPH but include maternal BMI anemia exposure."""
-        key_cols = ["sex", "age_start", "age_end", "year_start", "year_end", "maternal_bmi_anemia_exposure"]
+        key_cols = [
+            "sex",
+            "age_start",
+            "age_end",
+            "year_start",
+            "year_end",
+            "maternal_bmi_anemia_exposure",
+        ]
         key_cols = [k for k in key_cols if k in data.columns]
-        data = data.pivot_table(index=key_cols, columns="parameter", values="value").reset_index()
+        data = data.pivot_table(
+            index=key_cols, columns="parameter", values="value"
+        ).reset_index()
         data.columns.name = None
         return data
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -392,7 +392,7 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
         )
 
 
-    def _pivot_categorical(data: pd.DataFrame) -> pd.DataFrame:
+    def _pivot_categorical(self, data: pd.DataFrame) -> pd.DataFrame:
         """Pivots data that is long on categories to be wide.
         Copied from VPH but include maternal BMI anemia exposure."""
         key_cols = ["sex", "age_start", "age_end", "year_start", "year_end", "maternal_bmi_anemia_exposure"]

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -369,6 +369,9 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
 class BEPEffectOnBirthweight(AdditiveRiskEffect):
     '''Model effect of BEP on birthweight. Unique component because effect of BEP depends
     on mother's BMI status.'''
+    def __init__(self):
+        super().__init__('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
+
     def _get_excess_shift_source(self, builder: Builder) -> LookupTable:
         excess_shift_data = builder.data.load(
             f"{self.risk}.excess_shift",

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -386,10 +386,21 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
             affected_measure=self.target.measure,
         )
         excess_shift_data = rebin_relative_risk_data(builder, self.risk, excess_shift_data)
-        excess_shift_data = pivot_categorical(excess_shift_data)
+        excess_shift_data = self._pivot_categorical(excess_shift_data)
         return builder.lookup.build_table(
             excess_shift_data, key_columns=["sex", "maternal_bmi_anemia_exposure"], parameter_columns=["age", "year"]
         )
+
+
+    def _pivot_categorical(data: pd.DataFrame) -> pd.DataFrame:
+        """Pivots data that is long on categories to be wide.
+        Copied from VPH but include maternal BMI anemia exposure."""
+        key_cols = ["sex", "age_start", "age_end", "year_start", "year_end", "maternal_bmi_anemia_exposure"]
+        key_cols = [k for k in key_cols if k in data.columns]
+        data = data.pivot_table(index=key_cols, columns="parameter", values="value").reset_index()
+        data.columns.name = None
+        return data
+
 
     def get_effect(self, index: pd.Index) -> pd.Series:
         index_columns = ["index", self.risk.name]

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -374,7 +374,6 @@ class BEPEffectOnBirthweight(AdditiveRiskEffect):
 
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
-        self.effect = self._get_effect_pipeline(builder)
         self.excess_shift_source = self._get_excess_shift_source(builder)
         self.risk_specific_shift_source = self._get_risk_specific_shift_source(builder)
         self.population_view = builder.population.get_view(['maternal_bmi_anemia_exposure'])

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -366,6 +366,22 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
         return excess_shift
 
 
+class BEPEffectOnBirthweight(AdditiveRiskEffect):
+    '''Model effect of BEP on birthweight. Unique component because effect of BEP depends
+    on mother's BMI status.'''
+    def _get_excess_shift_source(self, builder: Builder) -> LookupTable:
+        excess_shift_data = builder.data.load(
+            f"{self.risk}.excess_shift",
+            affected_entity=self.target.name,
+            affected_measure=self.target.measure,
+        )
+        excess_shift_data = rebin_relative_risk_data(builder, self.risk, excess_shift_data)
+        excess_shift_data = pivot_categorical(excess_shift_data)
+        return builder.lookup.build_table(
+            excess_shift_data, key_columns=["sex", "maternal_bmi_anemia_exposure"], parameter_columns=["age", "year"]
+        )
+
+
 class BirthWeightShiftEffect:
     def __init__(self):
         self.ifa_effect_pipeline_name = f"{IFA_SUPPLEMENTATION.name}_on_birth_weight.effect"

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -319,8 +319,8 @@ class ChildWastingObserver(DiseaseObserver):
         #     )
 
         incident_transitions = [
-            TransitionString("moderate_acute_malnutrition_to_severe_acute_malnutrition"),
-            TransitionString("mild_child_wasting_to_moderate_acute_malnutrition"),
+            TransitionString("moderate_acute_malnutrition_TO_severe_acute_malnutrition"),
+            TransitionString("mild_child_wasting_TO_moderate_acute_malnutrition"),
         ]
 
         for transition in incident_transitions:

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -322,20 +322,21 @@ class ChildWastingObserver(DiseaseObserver):
             "mild_child_wasting_to_moderate_acute_malnutrition",
         ]
 
-        for transition in incident_transitions:
-            filter_string = (
-                f'{self.previous_state_column_name} == "{transition.from_state}" '
-                f'and {self.disease} == "{transition.to_state}" '
-                f"and tracked==True"
-            )
-            builder.results.register_observation(
-                name=f"{transition}_event_count",
-                pop_filter=filter_string,
-                requires_columns=[self.previous_state_column_name, self.disease],
-                additional_stratifications=self.config.include,
-                excluded_stratifications=self.config.exclude,
-                when="collect_metrics",
-            )
+        for transition in disease_model.transition_names:
+            if transition in incident_transitions:
+                filter_string = (
+                    f'{self.previous_state_column_name} == "{transition.from_state}" '
+                    f'and {self.disease} == "{transition.to_state}" '
+                    f"and tracked==True"
+                )
+                builder.results.register_observation(
+                    name=f"{transition}_event_count",
+                    pop_filter=filter_string,
+                    requires_columns=[self.previous_state_column_name, self.disease],
+                    additional_stratifications=self.config.include,
+                    excluded_stratifications=self.config.exclude,
+                    when="collect_metrics",
+                )
 
 
 class MortalityHazardRateObserver:

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -6,6 +6,7 @@ from vivarium import ConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
+from vivarium_public_health.disease.transition import TransitionString
 from vivarium_public_health.metrics.disability import (
     DisabilityObserver as DisabilityObserver_,
 )
@@ -318,25 +319,24 @@ class ChildWastingObserver(DiseaseObserver):
         #     )
 
         incident_transitions = [
-            "moderate_acute_malnutrition_to_severe_acute_malnutrition",
-            "mild_child_wasting_to_moderate_acute_malnutrition",
+            TransitionString("moderate_acute_malnutrition_to_severe_acute_malnutrition"),
+            TransitionString("mild_child_wasting_to_moderate_acute_malnutrition"),
         ]
 
-        for transition in disease_model.transition_names:
-            if transition in incident_transitions:
-                filter_string = (
-                    f'{self.previous_state_column_name} == "{transition.from_state}" '
-                    f'and {self.disease} == "{transition.to_state}" '
-                    f"and tracked==True"
-                )
-                builder.results.register_observation(
-                    name=f"{transition}_event_count",
-                    pop_filter=filter_string,
-                    requires_columns=[self.previous_state_column_name, self.disease],
-                    additional_stratifications=self.config.include,
-                    excluded_stratifications=self.config.exclude,
-                    when="collect_metrics",
-                )
+        for transition in incident_transitions:
+            filter_string = (
+                f'{self.previous_state_column_name} == "{transition.from_state}" '
+                f'and {self.disease} == "{transition.to_state}" '
+                f"and tracked==True"
+            )
+            builder.results.register_observation(
+                name=f"{transition}_event_count",
+                pop_filter=filter_string,
+                requires_columns=[self.previous_state_column_name, self.disease],
+                additional_stratifications=self.config.include,
+                excluded_stratifications=self.config.exclude,
+                when="collect_metrics",
+            )
 
 
 class MortalityHazardRateObserver:

--- a/src/vivarium_gates_nutrition_optimization_child/constants/data_values.py
+++ b/src/vivarium_gates_nutrition_optimization_child/constants/data_values.py
@@ -118,9 +118,13 @@ class __MaternalCharacteristics(NamedTuple):
     )
 
     BASELINE_BEP_COVERAGE: float = 0.0
-    BEP_BIRTH_WEIGHT_SHIFT: Tuple[str, stats.norm] = (
+    BEP_UNDERNOURISHED_BIRTH_WEIGHT_SHIFT: Tuple[str, stats.norm] = (
         "bep_birth_weight_shift",
         get_norm_from_quantiles(mean=66.96, lower=13.13, upper=120.78),
+    )
+    BEP_ADEQUATELY_NOURISHED_BIRTH_WEIGHT_SHIFT: Tuple[str, stats.norm] = (
+        "bep_birth_weight_shift",
+        get_norm_from_quantiles(mean=15.93, lower=-20.83, upper=52.69),
     )
 
     BASELINE_IV_IRON_COVERAGE: float = 0.0

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -1066,11 +1066,10 @@ def load_bep_excess_shift(key: str, location: str) -> pd.DataFrame:
     cat3_shift["maternal_bmi_anemia_exposure"] = 'cat3'
     cat4_shift["maternal_bmi_anemia_exposure"] = 'cat4'
 
-    df = pd.concat([cat1_shift, cat2_shift, cat3_shift, cat4_shift])
+    shift = pd.concat([cat1_shift, cat2_shift, cat3_shift, cat4_shift])
+    shift = shift.set_index('maternal_bmi_anemia_exposure', append=True)
 
-    breakpoint()
-
-    return 0
+    return shift.sort_index()
 
 
 def load_dichotomous_exposure(

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -1050,24 +1050,32 @@ def load_treatment_excess_shift(key: str, location: str) -> pd.DataFrame:
 
 
 def load_bep_excess_shift(key: str, location: str) -> pd.DataFrame:
-    undernourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_UNDERNOURISHED_BIRTH_WEIGHT_SHIFT
-    adequately_nourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_ADEQUATELY_NOURISHED_BIRTH_WEIGHT_SHIFT
+    undernourished_distribution = (
+        data_values.MATERNAL_CHARACTERISTICS.BEP_UNDERNOURISHED_BIRTH_WEIGHT_SHIFT
+    )
+    adequately_nourished_distribution = (
+        data_values.MATERNAL_CHARACTERISTICS.BEP_ADEQUATELY_NOURISHED_BIRTH_WEIGHT_SHIFT
+    )
 
-    undernourished_shift = load_dichotomous_excess_shift(location, undernourished_distribution)
-    adequately_nourished_shift = load_dichotomous_excess_shift(location, adequately_nourished_distribution)
+    undernourished_shift = load_dichotomous_excess_shift(
+        location, undernourished_distribution
+    )
+    adequately_nourished_shift = load_dichotomous_excess_shift(
+        location, adequately_nourished_distribution
+    )
 
     cat1_shift = undernourished_shift.copy()
     cat2_shift = adequately_nourished_shift.copy()
     cat3_shift = undernourished_shift.copy()
     cat4_shift = adequately_nourished_shift.copy()
 
-    cat1_shift["maternal_bmi_anemia_exposure"] = 'cat1'
-    cat2_shift["maternal_bmi_anemia_exposure"] = 'cat2'
-    cat3_shift["maternal_bmi_anemia_exposure"] = 'cat3'
-    cat4_shift["maternal_bmi_anemia_exposure"] = 'cat4'
+    cat1_shift["maternal_bmi_anemia_exposure"] = "cat1"
+    cat2_shift["maternal_bmi_anemia_exposure"] = "cat2"
+    cat3_shift["maternal_bmi_anemia_exposure"] = "cat3"
+    cat4_shift["maternal_bmi_anemia_exposure"] = "cat4"
 
     shift = pd.concat([cat1_shift, cat2_shift, cat3_shift, cat4_shift])
-    shift = shift.set_index('maternal_bmi_anemia_exposure', append=True)
+    shift = shift.set_index("maternal_bmi_anemia_exposure", append=True)
 
     return shift.sort_index()
 

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -1053,8 +1053,20 @@ def load_bep_excess_shift(key: str, location: str) -> pd.DataFrame:
     undernourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_UNDERNOURISHED_BIRTH_WEIGHT_SHIFT
     adequately_nourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_ADEQUATELY_NOURISHED_BIRTH_WEIGHT_SHIFT
 
-    undernourished_shift = load_dichotomous_excess_shift(location, adequately_nourished_distribution)
-    adequately_nourished_shift = load_dichotomous_excess_shift(location, undernourished_distribution)
+    undernourished_shift = load_dichotomous_excess_shift(location, undernourished_distribution)
+    adequately_nourished_shift = load_dichotomous_excess_shift(location, adequately_nourished_distribution)
+
+    cat1_shift = undernourished_shift.copy()
+    cat2_shift = adequately_nourished_shift.copy()
+    cat3_shift = undernourished_shift.copy()
+    cat4_shift = adequately_nourished_shift.copy()
+
+    cat1_shift["maternal_bmi_anemia_exposure"] = 'cat1'
+    cat2_shift["maternal_bmi_anemia_exposure"] = 'cat2'
+    cat3_shift["maternal_bmi_anemia_exposure"] = 'cat3'
+    cat4_shift["maternal_bmi_anemia_exposure"] = 'cat4'
+
+    df = pd.concat([cat1_shift, cat2_shift, cat3_shift, cat4_shift])
 
     breakpoint()
 

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -175,7 +175,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.BEP_SUPPLEMENTATION.DISTRIBUTION: load_intervention_distribution,
         data_keys.BEP_SUPPLEMENTATION.CATEGORIES: load_intervention_categories,
         data_keys.BEP_SUPPLEMENTATION.EXPOSURE: load_dichotomous_treatment_exposure,
-        data_keys.BEP_SUPPLEMENTATION.EXCESS_SHIFT: load_treatment_excess_shift,
+        data_keys.BEP_SUPPLEMENTATION.EXCESS_SHIFT: load_bep_excess_shift,
         data_keys.BEP_SUPPLEMENTATION.RISK_SPECIFIC_SHIFT: load_risk_specific_shift,
         data_keys.IV_IRON.DISTRIBUTION: load_intervention_distribution,
         data_keys.IV_IRON.CATEGORIES: load_intervention_categories,
@@ -1047,6 +1047,18 @@ def load_treatment_excess_shift(key: str, location: str) -> pd.DataFrame:
     except KeyError:
         raise ValueError(f"Unrecognized key {key}")
     return load_dichotomous_excess_shift(location, distribution_data)
+
+
+def load_bep_excess_shift(key: str, location: str) -> pd.DataFrame:
+    undernourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_UNDERNOURISHED_BIRTH_WEIGHT_SHIFT
+    adequately_nourished_distribution = data_values.MATERNAL_CHARACTERISTICS.BEP_ADEQUATELY_NOURISHED_BIRTH_WEIGHT_SHIFT
+
+    undernourished_shift = load_dichotomous_excess_shift(location, adequately_nourished_distribution)
+    adequately_nourished_shift = load_dichotomous_excess_shift(location, undernourished_distribution)
+
+    breakpoint()
+
+    return 0
 
 
 def load_dichotomous_exposure(

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -57,7 +57,7 @@ components:
 
 configuration:
     input_data:
-        input_draw_number: 0
+        input_draw_number: 29
         # Artifact can also be defined at runtime using -i flag
         artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
         fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
@@ -67,7 +67,7 @@ configuration:
     randomness:
         map_size: 1_000_000
         key_columns: ['entrance_time', 'age', 'maternal_id']
-        random_seed: 0
+        random_seed: 4344
     time:
         start:
             year: 2025

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -42,7 +42,6 @@ components:
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
             - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - AdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
-            #- AdditiveRiskEffect('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()
             - AdditiveRiskEffect('risk_factor.maternal_bmi_anemia', 'risk_factor.birth_weight.birth_exposure')
             - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.gestational_age.birth_exposure')
@@ -57,7 +56,7 @@ components:
 
 configuration:
     input_data:
-        input_draw_number: 29
+        input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
         artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
         fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
@@ -67,7 +66,7 @@ configuration:
     randomness:
         map_size: 1_000_000
         key_columns: ['entrance_time', 'age', 'maternal_id']
-        random_seed: 4344
+        random_seed: 0
     time:
         start:
             year: 2025

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -42,7 +42,8 @@ components:
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
             - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - AdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
-            - AdditiveRiskEffect('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
+            #- AdditiveRiskEffect('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.birth_weight.birth_exposure')
+            - BEPEffectOnBirthweight()
             - AdditiveRiskEffect('risk_factor.maternal_bmi_anemia', 'risk_factor.birth_weight.birth_exposure')
             - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.gestational_age.birth_exposure')
             - MMSEffectOnGestationalAge()
@@ -58,7 +59,7 @@ configuration:
     input_data:
         input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0/ethiopia.hdf'
+        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
         fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
     interpolation:
         order: 0


### PR DESCRIPTION
## update bep effect

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4552](https://jira.ihme.washington.edu/browse/MIC-4552)
- *Research reference*: [effect sizes](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_gates_bep/concept_model.html?highlight=balanced%20protein#effect-sizes)

### Changes and notes
Apply different birth effects for simulants with undernourished (cat1/cat3) vs adequately nourished (cat2/cat4) mothers.

### Verification and Testing
Added a breakpoint and population view to check that simulants were getting assigned appropriate effect sizes given their BMI/anemia exposure.