### PR TITLE
vivarium component refactor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
 
     install_requirements = [
         "gbd_mapping==3.1.1",
-        "vivarium==1.2.2",
-        "vivarium_public_health==1.0.1",
+        "vivarium>=2.0.0",
+        "vivarium_public_health>=2.0.0",
         "click",
         "jinja2",
         "loguru",
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     # use "pip install -e .[dev]" to install required components + extra components
     data_requires = [
-        "vivarium_cluster_tools==1.3.10",
+        "vivarium_cluster_tools==1.3.12",
         "vivarium_inputs[data]==4.1.1",
     ]
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -16,7 +16,6 @@ from vivarium_gates_nutrition_optimization_child.components.maternal_characteris
 from vivarium_gates_nutrition_optimization_child.components.observers import (
     BirthObserver,
     ChildWastingObserver,
-    # DisabilityObserver,
     MortalityHazardRateObserver,
     MortalityObserver,
     ResultsStratifier,

--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -16,7 +16,7 @@ from vivarium_gates_nutrition_optimization_child.components.maternal_characteris
 from vivarium_gates_nutrition_optimization_child.components.observers import (
     BirthObserver,
     ChildWastingObserver,
-    DisabilityObserver,
+    # DisabilityObserver,
     MortalityHazardRateObserver,
     MortalityObserver,
     ResultsStratifier,

--- a/src/vivarium_gates_nutrition_optimization_child/components/causes.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/causes.py
@@ -22,9 +22,9 @@ def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
     infected = DiseaseState(cause, get_data_functions=with_condition_data_functions)
 
     healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
+    healthy.add_rate_transition(infected)
     infected.allow_self_transitions()
-    infected.add_transition(healthy, source_data_type="rate")
+    infected.add_rate_transition(healthy)
 
     return DiseaseModel(cause, states=[healthy, infected])
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -29,13 +29,6 @@ class FertilityLineList(Component):
     def __init__(self):
         super().__init__()
 
-    # def __repr__(self):
-    #     return "FertilityLineList()"
-    #
-    # @property
-    # def name(self):
-    #     return "line_list_fertility"
-
     @property
     def columns_required(self) -> List[str]:
         return ["alive", "cause_of_death"]
@@ -51,11 +44,6 @@ class FertilityLineList(Component):
 
         # Requirements for input data
         self.birth_records = self._get_birth_records(builder)
-
-        #self.population_view = builder.population.get_view(["alive", "cause_of_death"])
-
-        # builder.event.register_listener("time_step", self.on_time_step)
-        # builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
 
 
     @staticmethod

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -7,9 +7,10 @@ Fertility module to create simulants from existing data
 
 """
 from pathlib import Path
-
+from typing import List
 import numpy as np
 import pandas as pd
+from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium_public_health import utilities
@@ -17,20 +18,31 @@ from vivarium_public_health import utilities
 PREGNANCY_DURATION = pd.Timedelta(days=9 * utilities.DAYS_PER_MONTH)
 
 
-class FertilityLineList:
+class FertilityLineList(Component):
     """
     This class will determine what simulants need to be added to the state table based on their birth data from existing
     line list data.  Simulants will be registered to the state table on the time steps in which their birth takes place.
     """
 
-    configuration_defaults = {}
+    CONFIGURATION_DEFAULTS = {}
 
-    def __repr__(self):
-        return "FertilityLineList()"
+    def __init__(self):
+        super().__init__()
+
+    # def __repr__(self):
+    #     return "FertilityLineList()"
+    #
+    # @property
+    # def name(self):
+    #     return "line_list_fertility"
 
     @property
-    def name(self):
-        return "line_list_fertility"
+    def columns_required(self) -> List[str]:
+        return ["alive", "cause_of_death"]
+
+    #################
+    # Setup methods #
+    #################
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
@@ -40,10 +52,11 @@ class FertilityLineList:
         # Requirements for input data
         self.birth_records = self._get_birth_records(builder)
 
-        self.population_view = builder.population.get_view(["alive", "cause_of_death"])
+        #self.population_view = builder.population.get_view(["alive", "cause_of_death"])
 
-        builder.event.register_listener("time_step", self.on_time_step)
-        builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
+        # builder.event.register_listener("time_step", self.on_time_step)
+        # builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
+
 
     @staticmethod
     def _get_birth_records(builder: Builder) -> pd.DataFrame:
@@ -71,7 +84,7 @@ class FertilityLineList:
         born_previous_step_mask = (birth_records["birth_date"] < self.clock()) & (
             birth_records["birth_date"] > self.clock() - event.step_size
         )
-        born_previous_step = birth_records[born_previous_step_mask].copy()
+        born_previous_step = birth_records[born_previous_step_mask].reset_index().copy()
         # everyone is currently born on the first time step so this is always empty after the first time step
         if born_previous_step.empty:
             return

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -72,7 +72,7 @@ class FertilityLineList(Component):
         born_previous_step_mask = (birth_records["birth_date"] < self.clock()) & (
             birth_records["birth_date"] > self.clock() - event.step_size
         )
-        born_previous_step = birth_records[born_previous_step_mask].reset_index().copy()
+        born_previous_step = birth_records[born_previous_step_mask].copy()
         # everyone is currently born on the first time step so this is always empty after the first time step
         if born_previous_step.empty:
             return

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -8,6 +8,7 @@ Fertility module to create simulants from existing data
 """
 from pathlib import Path
 from typing import List
+
 import numpy as np
 import pandas as pd
 from vivarium import Component
@@ -44,7 +45,6 @@ class FertilityLineList(Component):
 
         # Requirements for input data
         self.birth_records = self._get_birth_records(builder)
-
 
     @staticmethod
     def _get_birth_records(builder: Builder) -> pd.DataFrame:

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -42,13 +42,6 @@ class LBWSGLineList(LBWSGRisk):
         super().__init__()
         self.raw_gestational_age_exposure_column_name = "raw_gestational_age_exposure"
 
-    # @property
-    # def name(self) -> str:
-    #     return "line_list_low_birth_weight_and_short_gestation"
-    #
-    # def __repr__(self):
-    #     return "LBWSGLineList()"
-
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         super().setup(builder)
@@ -65,20 +58,6 @@ class LBWSGLineList(LBWSGRisk):
         return {
             self.birth_exposure_pipeline_name(axis): get_pipeline(axis) for axis in self.AXES
         }
-
-    # def _get_population_view(self, builder: Builder) -> PopulationView:
-    #     columns = [self.exposure_column_name(axis) for axis in self.AXES] + [
-    #         self.raw_gestational_age_exposure_column_name
-    #     ]
-    #     return builder.population.get_view(columns)
-
-    # def _register_simulant_initializer(self, builder: Builder) -> None:
-    #     builder.population.initializes_simulants(
-    #         self.on_initialize_simulants,
-    #         creates_columns=[self.exposure_column_name(axis) for axis in self.AXES]
-    #         + [self.raw_gestational_age_exposure_column_name],
-    #         requires_streams=[self.randomness_stream_name],
-    #     )
 
     ########################
     # Event-driven methods #

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -7,7 +7,7 @@ This is a module to subclass the LBWSG component in Vivrium Public Health to use
 simulants who are initialized from line list data.
 
 """
-from typing import Dict
+from typing import Dict, List
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -26,28 +26,39 @@ class LBWSGLineList(LBWSGRisk):
     """
     Component to initialize low birthweight and short gestation data for simulants based on existing line list data.
     """
+    @property
+    def columns_created(self) -> List[str]:
+        return [self.exposure_column_name(axis) for axis in self.AXES]+[self.raw_gestational_age_exposure_column_name]
+
+    @property
+    def initialization_requirements(self) -> Dict[str, List[str]]:
+        return {
+            "requires_columns": [],
+            "requires_values": [],
+            "requires_streams": [self.randomness_stream_name],
+        }
 
     def __init__(self):
         super().__init__()
         self.raw_gestational_age_exposure_column_name = "raw_gestational_age_exposure"
 
-    @property
-    def name(self) -> str:
-        return "line_list_low_birth_weight_and_short_gestation"
-
-    def __repr__(self):
-        return "LBWSGLineList()"
+    # @property
+    # def name(self) -> str:
+    #     return "line_list_low_birth_weight_and_short_gestation"
+    #
+    # def __repr__(self):
+    #     return "LBWSGLineList()"
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         super().setup(builder)
         self.start_time = get_time_stamp(builder.configuration.time.start)
 
-    def _get_birth_exposure_pipelines(self, builder: Builder) -> Dict[str, Pipeline]:
+    def get_birth_exposure_pipelines(self, builder: Builder) -> Dict[str, Pipeline]:
         def get_pipeline(axis_: str):
             return builder.value.register_value_producer(
                 self.birth_exposure_pipeline_name(axis_),
-                source=lambda index: self._get_birth_exposure(axis_, index),
+                source=lambda index: self.get_birth_exposure(axis_, index),
                 preferred_post_processor=get_exposure_post_processor(builder, self.risk),
             )
 
@@ -55,19 +66,19 @@ class LBWSGLineList(LBWSGRisk):
             self.birth_exposure_pipeline_name(axis): get_pipeline(axis) for axis in self.AXES
         }
 
-    def _get_population_view(self, builder: Builder) -> PopulationView:
-        columns = [self.exposure_column_name(axis) for axis in self.AXES] + [
-            self.raw_gestational_age_exposure_column_name
-        ]
-        return builder.population.get_view(columns)
+    # def _get_population_view(self, builder: Builder) -> PopulationView:
+    #     columns = [self.exposure_column_name(axis) for axis in self.AXES] + [
+    #         self.raw_gestational_age_exposure_column_name
+    #     ]
+    #     return builder.population.get_view(columns)
 
-    def _register_simulant_initializer(self, builder: Builder) -> None:
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[self.exposure_column_name(axis) for axis in self.AXES]
-            + [self.raw_gestational_age_exposure_column_name],
-            requires_streams=[self._randomness_stream_name],
-        )
+    # def _register_simulant_initializer(self, builder: Builder) -> None:
+    #     builder.population.initializes_simulants(
+    #         self.on_initialize_simulants,
+    #         creates_columns=[self.exposure_column_name(axis) for axis in self.AXES]
+    #         + [self.raw_gestational_age_exposure_column_name],
+    #         requires_streams=[self.randomness_stream_name],
+    #     )
 
     ########################
     # Event-driven methods #
@@ -95,5 +106,5 @@ class LBWSGLineList(LBWSGRisk):
     # Pipeline sources and modifiers #
     ##################################
 
-    def _get_birth_exposure(self, axis: str, index: pd.Index) -> pd.Series:
+    def get_birth_exposure(self, axis: str, index: pd.Index) -> pd.Series:
         return self.new_births.loc[index, axis]

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -26,9 +26,12 @@ class LBWSGLineList(LBWSGRisk):
     """
     Component to initialize low birthweight and short gestation data for simulants based on existing line list data.
     """
+
     @property
     def columns_created(self) -> List[str]:
-        return [self.exposure_column_name(axis) for axis in self.AXES]+[self.raw_gestational_age_exposure_column_name]
+        return [self.exposure_column_name(axis) for axis in self.AXES] + [
+            self.raw_gestational_age_exposure_column_name
+        ]
 
     @property
     def initialization_requirements(self) -> Dict[str, List[str]]:

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -2,11 +2,10 @@
 Component for maternal supplementation and risk effects
 """
 
-from typing import Callable, Dict
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from typing import Optional, List
 from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
@@ -79,7 +78,10 @@ class MaternalCharacteristics(Component):
 
     @property
     def columns_created(self) -> List[str]:
-        return [self.supplementation_exposure_column_name,self.maternal_bmi_anemia_exposure_column_name]
+        return [
+            self.supplementation_exposure_column_name,
+            self.maternal_bmi_anemia_exposure_column_name,
+        ]
 
     #################
     # Setup methods #

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -73,13 +73,6 @@ class MaternalCharacteristics(Component):
         self.mmn_exposure_pipeline_name = f"{MMN_SUPPLEMENTATION.name}.exposure"
         self.maternal_bmi_anemia_exposure_pipeline_name = "maternal_bmi_anemia.exposure"
 
-    # def __repr__(self):
-    #     return "MaternalCharacteristics()"
-    #
-    # @property
-    # def name(self) -> str:
-    #     return "maternal_characteristics"
-
     @property
     def columns_required(self) -> List[str]:
         return ["alive", "cause_of_death"]
@@ -116,19 +109,6 @@ class MaternalCharacteristics(Component):
             requires_columns=[self.maternal_bmi_anemia_exposure_column_name],
         )
 
-        #self.population_view = self._get_population_view(builder)
-
-        # self._register_simulant_initializer(builder)
-
-    # def _register_simulant_initializer(self, builder: Builder) -> None:
-    #     builder.population.initializes_simulants(
-    #         self.on_initialize_simulants,
-    #         creates_columns=[
-    #             self.supplementation_exposure_column_name,
-    #             self.maternal_bmi_anemia_exposure_column_name,
-    #         ],
-    #     )
-
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """
         Initialize simulants from line list data. Population configuration
@@ -152,14 +132,6 @@ class MaternalCharacteristics(Component):
             ]
 
         self.population_view.update(new_simulants)
-
-    # def _get_population_view(self, builder: Builder) -> PopulationView:
-    #     return builder.population.get_view(
-    #         [
-    #             self.supplementation_exposure_column_name,
-    #             self.maternal_bmi_anemia_exposure_column_name,
-    #         ]
-    #     )
 
     ##################################
     # Pipeline sources and modifiers #
@@ -311,7 +283,6 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        # self.population_view = self._get_population_view(builder)
         self.ifa_on_gestational_age = builder.components.get_component(
             f"additive_risk_effect.risk_factor.iron_folic_acid_supplementation.{self.target}"
         )
@@ -321,9 +292,6 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
         self.mms_subpop_2_excess_shift = self._get_mms_excess_shift_data(
             builder, data_keys.MMN_SUPPLEMENTATION.EXCESS_GA_SHIFT_SUBPOP_2
         )
-
-    # def _get_population_view(self, builder: Builder) -> PopulationView:
-    #     return builder.population.get_view([self.raw_gestational_age_exposure_column_name])
 
     def _get_mms_excess_shift_data(
         self, builder: Builder, key: str
@@ -434,17 +402,6 @@ class BirthWeightShiftEffect(Component):
         self.wasting_exposure_parameters_pipeline_name = (
             f"risk_factor.{WASTING.name}.exposure_parameters"
         )
-
-    # def __repr__(self):
-    #     return f"BirthWeightShiftEffect()"
-    #
-    # ##############
-    # # Properties #
-    # ##############
-    #
-    # @property
-    # def name(self) -> str:
-    #     return f"birth_weight_shift_effect"
 
     #################
     # Setup methods #

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -147,17 +147,6 @@ class ResultsStratifier(ResultsStratifier_):
         return age_group
 
 
-# class DisabilityObserver(DisabilityObserver_):
-#     def on_post_setup(self, event: Event) -> None:
-#         cause_states = builder.components.get_components_by_type(tuple(self.disease_classes))
-#         for cause in self._cause_components:
-#             if (
-#                 cause.has_disability
-#                 or cause.name == "disease_model.moderate_protein_energy_malnutrition"
-#             ):
-#                 self.disability_pipelines[cause.state_id] = cause.disability_weight
-
-
 class BirthObserver(Component):
     CONFIGURATION_DEFAULTS = {
         "stratification": {

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -263,8 +263,9 @@ class ChildWastingObserver(DiseaseObserver):
         self.config = builder.configuration.stratification[self.disease]
         self.categories = builder.data.load(f"risk_factor.{self.risk}.categories")
 
-        disease_model = builder.components.get_component(f"disease_model.{self.disease}")
+        disease_model = builder.components.get_component(f"dynamic_child_wasting_model.{self.disease}")
 
+        # not needed in current output but keeping just in case we want to add it back
         # for category in self.categories:
         #     builder.results.register_observation(
         #         name=f"{self.risk}_{category}_person_time",

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -1,10 +1,8 @@
 from collections import Counter
-from typing import Dict
+from typing import Dict, List, Optional
 
 import pandas as pd
-from typing import Optional, List
-from vivarium import ConfigTree
-from vivarium import Component
+from vivarium import Component, ConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
@@ -165,10 +163,10 @@ class BirthObserver(Component):
     @property
     def columns_required(self) -> Optional[List[str]]:
         return [
-        "entrance_time",
-        self.birth_weight_column_name,
-        self.gestational_age_column_name,
-    ]
+            "entrance_time",
+            self.birth_weight_column_name,
+            self.gestational_age_column_name,
+        ]
 
     #################
     # Setup methods #
@@ -245,7 +243,7 @@ class MortalityObserver(MortalityObserver_):
 
 class ChildWastingObserver(DiseaseObserver):
     def __init__(self):
-        super().__init__('child_wasting')
+        super().__init__("child_wasting")
         self.disease = self.risk = "child_wasting"
         self.exposure_pipeline_name = f"{self.risk}.exposure"
 
@@ -263,7 +261,9 @@ class ChildWastingObserver(DiseaseObserver):
         self.config = builder.configuration.stratification[self.disease]
         self.categories = builder.data.load(f"risk_factor.{self.risk}.categories")
 
-        disease_model = builder.components.get_component(f"dynamic_child_wasting_model.{self.disease}")
+        disease_model = builder.components.get_component(
+            f"dynamic_child_wasting_model.{self.disease}"
+        )
 
         # not needed in current output but keeping just in case we want to add it back
         # for category in self.categories:

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -94,12 +94,12 @@ class ResultsStratifier(ResultsStratifier_):
             is_vectorized=True,
             requires_values=[f"{data_keys.MAM_TREATMENT.name}.exposure"],
         )
-        # builder.results.register_stratification(
-        #     "sqlns_coverage",
-        #     ["covered", "uncovered", "received"],
-        #     is_vectorized=True,
-        #     requires_values=[data_values.SQ_LNS.COVERAGE_PIPELINE],
-        # )
+        builder.results.register_stratification(
+            "sqlns_coverage",
+            ["covered", "uncovered", "received"],
+            is_vectorized=True,
+            requires_values=[data_values.SQ_LNS.COVERAGE_PIPELINE],
+        )
 
     ###########################
     # Stratifications Details #
@@ -173,17 +173,6 @@ class BirthObserver(Component):
         self.gestational_age_column_name = "gestational_age_exposure"
         self.low_birth_weight_limit = 2500  # grams
 
-    # def __repr__(self):
-    #     return "BirthObserver()"
-    #
-    # ##############
-    # # Properties #
-    # ##############
-    #
-    # @property
-    # def name(self):
-    #     return "birth_observer"
-
     @property
     def columns_required(self) -> Optional[List[str]]:
         return [
@@ -200,8 +189,6 @@ class BirthObserver(Component):
     def setup(self, builder: Builder) -> None:
         self.clock = builder.time.clock()
         self.config = builder.configuration.stratification.birth
-
-        #self.population_view = builder.population.get_view(columns_required)
 
         builder.results.register_observation(
             name=f"live_births",
@@ -273,17 +260,6 @@ class ChildWastingObserver(DiseaseObserver):
         self.disease = self.risk = "child_wasting"
         self.exposure_pipeline_name = f"{self.risk}.exposure"
 
-    # def __repr__(self):
-    #     return "ChildWastingObserver()"
-    #
-    # ##############
-    # # Properties #
-    # ##############
-    #
-    # @property
-    # def name(self):
-    #     return "child_wasting_observer"
-
     @property
     def columns_required(self) -> Optional[List[str]]:
         return [self.disease]
@@ -299,14 +275,6 @@ class ChildWastingObserver(DiseaseObserver):
         self.categories = builder.data.load(f"risk_factor.{self.risk}.categories")
 
         disease_model = builder.components.get_component(f"disease_model.{self.disease}")
-
-        # builder.population.initializes_simulants(
-        #     self.on_initialize_simulants, creates_columns=[self.previous_state_column_name]
-        # )
-
-        # self.population_view = builder.population.get_view(columns_required)
-        #
-        # builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
 
         # for category in self.categories:
         #     builder.results.register_observation(
@@ -349,17 +317,6 @@ class MortalityHazardRateObserver(Component):
     def __init__(self):
         super().__init__()
         self.mortality_rate_pipeline_name = "mortality_rate"
-
-    # def __repr__(self):
-    #     return "MortalityHazardRateObserver()"
-    #
-    # ##############
-    # # Properties #
-    # ##############
-    #
-    # @property
-    # def name(self):
-    #     return "mortality_hazard_rate_observer"
 
     #################
     # Setup methods #

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -72,7 +72,6 @@ class PopulationLineList(BasePopulation):
         }
         self.register_simulants = builder.randomness.register_simulants
 
-        # builder.event.register_listener("time_step", self.on_time_step, priority=8)
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.location = self._get_location(builder)
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -7,6 +7,7 @@ This module contains a component for creating a base population from line list d
 
 """
 import glob
+from typing import List
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -23,6 +24,22 @@ class PopulationLineList(BasePopulation):
     """
     Component to produce and age simulants based on line list data.
     """
+    @property
+    def columns_created(self) -> List[str]:
+        return [
+            "age",
+            "sex",
+            "alive",
+            "location",
+            "entrance_time",
+            "exit_time",
+            "maternal_id",
+        ]
+
+    @property
+    def time_step_priority(self) -> int:
+        return 8
+
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
@@ -55,47 +72,28 @@ class PopulationLineList(BasePopulation):
         }
         self.register_simulants = builder.randomness.register_simulants
 
-        columns = [
-            "age",
-            "sex",
-            "alive",
-            "location",
-            "entrance_time",
-            "exit_time",
-            "maternal_id",
-        ]
+        #self.population_view = builder.population.get_view(columns)
+        # builder.population.initializes_simulants(
+        #     self.on_initialize_simulants, creates_columns=columns
+        # )
 
-        self.population_view = builder.population.get_view(columns)
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants, creates_columns=columns
-        )
-
-        builder.event.register_listener("time_step", self.on_time_step, priority=8)
+        # builder.event.register_listener("time_step", self.on_time_step, priority=8)
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.location = self._get_location(builder)
 
-    @property
-    def name(self) -> str:
-        return "line_list_population"
-
-    def __repr__(self) -> str:
-        return "PopulationLineList()"
+    # @property
+    # def name(self) -> str:
+    #     return "line_list_population"
+    #
+    # def __repr__(self) -> str:
+    #     return "PopulationLineList()"
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """
         Creates simulants based on their birth date from the line list data.  Their demographic characteristics are also
         determined by the input data.
         """
-        columns = [
-            "age",
-            "sex",
-            "alive",
-            "location",
-            "entrance_time",
-            "exit_time",
-            "maternal_id",
-        ]
-        new_simulants = pd.DataFrame(columns=columns, index=pop_data.index)
+        new_simulants = pd.DataFrame(columns=self.columns_created, index=pop_data.index)
 
         if pop_data.creation_time >= self.start_time:
             new_births = pop_data.user_data["new_births"]

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -24,6 +24,7 @@ class PopulationLineList(BasePopulation):
     """
     Component to produce and age simulants based on line list data.
     """
+
     @property
     def columns_created(self) -> List[str]:
         return [
@@ -39,7 +40,6 @@ class PopulationLineList(BasePopulation):
     @property
     def time_step_priority(self) -> int:
         return 8
-
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -72,21 +72,9 @@ class PopulationLineList(BasePopulation):
         }
         self.register_simulants = builder.randomness.register_simulants
 
-        #self.population_view = builder.population.get_view(columns)
-        # builder.population.initializes_simulants(
-        #     self.on_initialize_simulants, creates_columns=columns
-        # )
-
         # builder.event.register_listener("time_step", self.on_time_step, priority=8)
         self.start_time = get_time_stamp(builder.configuration.time.start)
         self.location = self._get_location(builder)
-
-    # @property
-    # def name(self) -> str:
-    #     return "line_list_population"
-    #
-    # def __repr__(self) -> str:
-    #     return "PopulationLineList()"
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """

--- a/src/vivarium_gates_nutrition_optimization_child/components/risk.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/risk.py
@@ -116,9 +116,6 @@ class CGFRiskEffect(RiskEffect):
         for sub_risk in self.cgf_models:
             config.update(get_config_by_risk(sub_risk))
         return config
-    # @property
-    # def name(self) -> str:
-    #     return f"risk_effect_{self.target}"
 
     def __init__(self, target: str):
         """
@@ -130,7 +127,6 @@ class CGFRiskEffect(RiskEffect):
             where entity_type should be singular (e.g., cause instead of causes).
         """
         super().__init__("risk_factor.child_growth_failure", target)
-        #self.risk = EntityString("risk_factor.child_growth_failure")
         self.cgf_models = [
             EntityString(f"risk_factor.{risk}")
             for risk in [

--- a/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
@@ -97,13 +97,6 @@ class SQLNSTreatment(Component):
             requires_values=[self.coverage_pipeline_name],
         )
 
-        # self.population_view = builder.population.get_view(required_columns)
-        # builder.population.initializes_simulants(
-        #     self.on_initialize_simulants,
-        #     creates_columns=[self.propensity_column_name],
-        #     requires_streams=[self._randomness_stream_name],
-        # )
-
     def get_coverage_value(self, builder: Builder) -> float:
         scenario = scenarios.INTERVENTION_SCENARIOS[
             builder.configuration.intervention.child_scenario

--- a/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
@@ -1,5 +1,6 @@
 """Prevention and treatment models"""
 from typing import Dict, List, Optional
+
 import pandas as pd
 from vivarium import Component
 from vivarium.framework.engine import Builder
@@ -15,9 +16,10 @@ from vivarium_gates_nutrition_optimization_child.constants import (
 
 class SQLNSTreatment(Component):
     """Manages SQ-LNS prevention"""
+
     @property
     def columns_required(self) -> Optional[List[str]]:
-        return ['age']
+        return ["age"]
 
     @property
     def columns_created(self) -> Optional[List[str]]:
@@ -31,14 +33,12 @@ class SQLNSTreatment(Component):
             "requires_streams": [self._randomness_stream_name],
         }
 
-
     def __init__(self):
         super().__init__()
         self._randomness_stream_name = f"initial_{self.name}_propensity"
         self.propensity_column_name = data_values.SQ_LNS.PROPENSITY_COLUMN
         self.propensity_pipeline_name = data_values.SQ_LNS.PROPENSITY_PIPELINE
         self.coverage_pipeline_name = data_values.SQ_LNS.COVERAGE_PIPELINE
-
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):

--- a/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
@@ -1,5 +1,7 @@
 """Prevention and treatment models"""
+from typing import Dict, List, Optional
 import pandas as pd
+from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 
@@ -11,19 +13,35 @@ from vivarium_gates_nutrition_optimization_child.constants import (
 )
 
 
-class SQLNSTreatment:
+class SQLNSTreatment(Component):
     """Manages SQ-LNS prevention"""
+    @property
+    def columns_required(self) -> Optional[List[str]]:
+        return ['age']
+
+    @property
+    def columns_created(self) -> Optional[List[str]]:
+        return [self.propensity_column_name]
+
+    @property
+    def initialization_requirements(self) -> Dict[str, List[str]]:
+        return {
+            "requires_columns": [],
+            "requires_values": [],
+            "requires_streams": [self._randomness_stream_name],
+        }
+
 
     def __init__(self):
-        self.name = "sq_lns"
+        super().__init__()
         self._randomness_stream_name = f"initial_{self.name}_propensity"
         self.propensity_column_name = data_values.SQ_LNS.PROPENSITY_COLUMN
         self.propensity_pipeline_name = data_values.SQ_LNS.PROPENSITY_PIPELINE
         self.coverage_pipeline_name = data_values.SQ_LNS.COVERAGE_PIPELINE
 
+
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
-        draw = builder.configuration.input_data.input_draw_number
         self.randomness = builder.randomness.get_stream(self._randomness_stream_name)
 
         self.coverage_value = self.get_coverage_value(builder)
@@ -41,8 +59,6 @@ class SQLNSTreatment:
         self.moderate_stunting_risk_ratio = self.get_risk_ratios(
             builder, "moderate_stunting_prevalence_ratio"
         )
-
-        required_columns = ["age", self.propensity_column_name]
 
         self.propensity = builder.value.register_value_producer(
             self.propensity_pipeline_name,
@@ -81,12 +97,12 @@ class SQLNSTreatment:
             requires_values=[self.coverage_pipeline_name],
         )
 
-        self.population_view = builder.population.get_view(required_columns)
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[self.propensity_column_name],
-            requires_streams=[self._randomness_stream_name],
-        )
+        # self.population_view = builder.population.get_view(required_columns)
+        # builder.population.initializes_simulants(
+        #     self.on_initialize_simulants,
+        #     creates_columns=[self.propensity_column_name],
+        #     requires_streams=[self._randomness_stream_name],
+        # )
 
     def get_coverage_value(self, builder: Builder) -> float:
         scenario = scenarios.INTERVENTION_SCENARIOS[

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -2,6 +2,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
@@ -11,7 +12,6 @@ from vivarium_public_health.risks.data_transformations import (
     get_exposure_post_processor,
 )
 from vivarium_public_health.utilities import EntityString
-from vivarium import Component
 
 from vivarium_gates_nutrition_optimization_child.constants import (
     data_keys,

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -174,10 +174,6 @@ class WastingTreatment(Risk):
 
 class DynamicChildWastingModel(DiseaseModel):
     @property
-    def name(self):
-        return f"disease_model.child_wasting"
-
-    @property
     def columns_created(self) -> List[str]:
         return [self.state_column]
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -27,21 +27,12 @@ from vivarium_gates_nutrition_optimization_child.utilities import get_random_var
 class ChildWasting(Component):
     @property
     def columns_required(self) -> Optional[List[str]]:
-        #return ["alive","age","sex",self.dynamic_model.state_column,self.static_model.propensity_column_name]
         return ["alive", "age", self.dynamic_model.state_column]
-
-    # @property
-    # def initialization_requirements(self) -> Dict[str, List[str]]:
-    #     return {
-    #         "requires_columns": ["age", "sex", self.static_model.propensity_column_name],
-    #         "requires_values": [self.static_model.exposure_pipeline_name],
-    #         "requires_streams": [],
-    #     }
 
     @property
     def initialization_requirements(self) -> Dict[str, List[str]]:
         return {
-            "requires_columns": ["age", "sex", self.static_model.propensity_column_name],
+            "requires_columns": ["sex", self.static_model.propensity_column_name],
             "requires_values": [self.static_model.exposure_pipeline_name],
             "requires_streams": [],
         }
@@ -58,25 +49,8 @@ class ChildWasting(Component):
             self.static_model,
         ]
 
-    # @property
-    # def name(self):
-    #     return f"child_wasting"
-    #
-    # def __repr__(self):
-    #     self._repr = "ChildWasting()"
-    #     return self._repr
-
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
-        # self.population_view = builder.population.get_view(
-        #     [
-        #         "alive",
-        #         "age",
-        #         "sex",
-        #         self.dynamic_model.state_column,
-        #         self.static_model.propensity_column_name,
-        #     ]
-        # )
         self.exposure = builder.value.register_value_producer(
             f"{self.name}.exposure",
             source=self.get_current_exposure,
@@ -156,18 +130,6 @@ class WastingTreatment(Risk):
         self.scenario = scenarios.INTERVENTION_SCENARIOS[
             builder.configuration.intervention.child_scenario
         ]
-        # self._register_on_time_step_prepare_listener(builder)
-
-    # def _get_population_view(self, builder: Builder) -> PopulationView:
-    #     return builder.population.get_view(
-    #         [self.propensity_column_name, self.previous_wasting_column, self.wasting_column]
-    #     )
-
-    # def _register_on_time_step_prepare_listener(self, builder: Builder) -> None:
-    #     # we want to reset propensities before updating previous state column
-    #     builder.event.register_listener(
-    #         "time_step__prepare", self.on_time_step_prepare, priority=4
-    #     )
 
     ########################
     # Event-driven methods #
@@ -249,18 +211,6 @@ class DynamicChildWastingModel(DiseaseModel):
             self.adjust_cause_specific_mortality_rate,
             requires_columns=["age", "sex"],
         )
-
-        # self.population_view = builder.population.get_view(
-        #     ["age", "sex", self.state_column, "static_child_wasting_propensity"]
-        # )
-        # builder.population.initializes_simulants(
-        #     self.on_initialize_simulants,
-        #     creates_columns=[self.state_column],
-        #     requires_columns=["age", "sex", "static_child_wasting_propensity"],
-        # )
-
-        # builder.event.register_listener("time_step", self.on_time_step)
-        # builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
 
     def on_initialize_simulants(self, pop_data):
         population = self.population_view.subview(

--- a/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
+++ b/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
@@ -41,7 +41,9 @@ class __DiarrhealDiseases(NamedTuple):
     DURATION: TargetString = TargetString("cause.diarrheal_diseases.duration")
     PREVALENCE: TargetString = TargetString("cause.diarrheal_diseases.prevalence")
     INCIDENCE_RATE: TargetString = TargetString("cause.diarrheal_diseases.incidence_rate")
-    REMISSION_RATE: TargetString = TargetString("cause.susceptible_to_diarrheal_diseases.remission_rate")
+    REMISSION_RATE: TargetString = TargetString(
+        "cause.susceptible_to_diarrheal_diseases.remission_rate"
+    )
     DISABILITY_WEIGHT: TargetString = TargetString(
         "cause.diarrheal_diseases.disability_weight"
     )

--- a/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
+++ b/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
@@ -41,7 +41,7 @@ class __DiarrhealDiseases(NamedTuple):
     DURATION: TargetString = TargetString("cause.diarrheal_diseases.duration")
     PREVALENCE: TargetString = TargetString("cause.diarrheal_diseases.prevalence")
     INCIDENCE_RATE: TargetString = TargetString("cause.diarrheal_diseases.incidence_rate")
-    REMISSION_RATE: TargetString = TargetString("cause.diarrheal_diseases.remission_rate")
+    REMISSION_RATE: TargetString = TargetString("cause.susceptible_to_diarrheal_diseases.remission_rate")
     DISABILITY_WEIGHT: TargetString = TargetString(
         "cause.diarrheal_diseases.disability_weight"
     )
@@ -97,7 +97,7 @@ class __LowerRespiratoryInfections(NamedTuple):
         "cause.lower_respiratory_infections.incidence_rate"
     )
     REMISSION_RATE: TargetString = TargetString(
-        "cause.lower_respiratory_infections.remission_rate"
+        "cause.susceptible_to_lower_respiratory_infections.remission_rate"
     )
     DISABILITY_WEIGHT: TargetString = TargetString(
         "cause.lower_respiratory_infections.disability_weight"
@@ -131,7 +131,7 @@ class __Malaria(NamedTuple):
     DURATION: TargetString = TargetString("cause.malaria.duration")
     PREVALENCE: TargetString = TargetString("cause.malaria.prevalence")
     INCIDENCE_RATE: TargetString = TargetString("cause.malaria.incidence_rate")
-    REMISSION_RATE: TargetString = TargetString("cause.malaria.remission_rate")
+    REMISSION_RATE: TargetString = TargetString("cause.susceptible_to_malaria.remission_rate")
     DISABILITY_WEIGHT: TargetString = TargetString("cause.malaria.disability_weight")
     EMR: TargetString = TargetString("cause.malaria.excess_mortality_rate")
     CSMR: TargetString = TargetString("cause.malaria.cause_specific_mortality_rate")

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -17,6 +17,7 @@ components:
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         metrics:
+            - DisabilityObserver()
             - CategoricalRiskObserver('child_stunting')
 
     vivarium_gates_nutrition_optimization_child:
@@ -24,7 +25,6 @@ components:
             - PopulationLineList()
             - FertilityLineList()
             - LBWSGLineList()
-            - DisabilityObserver()
             - ChildWasting()
             - ChildWastingObserver()
             - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
@@ -57,8 +57,10 @@ configuration:
     input_data:
         input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
-        fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
+        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
+        #fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
+        artifact_path: '/home/hussain-jafari/artifacts/nutrition/model8.1/ethiopia.hdf'
+        fertility_input_data_path: '/home/hussain-jafari/artifacts/nutrition/child_data'
     interpolation:
         order: 0
         extrapolate: True
@@ -72,9 +74,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2029
-            month: 12
-            day: 31
+            year: 2025
+            month: 1
+            day: 9
         step_size: 4 # Days
     population:
         population_size: 0
@@ -114,6 +116,6 @@ configuration:
             - 'age_group'
         child_wasting:
             include: ['mam_treatment', 'sam_treatment']
-        child_stunting:
-            include:
-                - 'sqlns_coverage'
+#        child_stunting:
+#            include:
+#                - 'sqlns_coverage'

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -57,10 +57,8 @@ configuration:
     input_data:
         input_draw_number: 0
         # Artifact can also be defined at runtime using -i flag
-        #artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
-        #fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
-        artifact_path: '/home/hussain-jafari/artifacts/nutrition/model8.1/ethiopia.hdf'
-        fertility_input_data_path: '/home/hussain-jafari/artifacts/nutrition/child_data'
+        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization_child/model8.0.1/ethiopia.hdf'
+        fertility_input_data_path: '/mnt/team/simulation_science/costeffectiveness/results/vivarium_gates_nutrition_optimization/model9.1/ethiopia/2023_09_14_15_12_50/child_data'
     interpolation:
         order: 0
         extrapolate: True
@@ -74,9 +72,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2025
-            month: 1
-            day: 9
+            year: 2029
+            month: 12
+            day: 31
         step_size: 4 # Days
     population:
         population_size: 0
@@ -116,6 +114,6 @@ configuration:
             - 'age_group'
         child_wasting:
             include: ['mam_treatment', 'sam_treatment']
-#        child_stunting:
-#            include:
-#                - 'sqlns_coverage'
+        child_stunting:
+            include:
+                - 'sqlns_coverage'


### PR DESCRIPTION
## vivarium component refactor

### Description
- *Category*: refactor
- *JIRA issue*: [MIC-4417](https://jira.ihme.washington.edu/browse/MIC-4417)

### Changes and notes
Update setup.py.
Use add_rate_transition instead of add_transition with source_data_type.
Subclass component and, where necessary, define columns required and created, initialization requirements, and event priorities.
Use public method names instead of private where necessary.
Update references to names generated by component.
Update artifact key names for remission rates.
Use VPH disability observer which no longer needs to be subclassed. 

### Verification and Testing
Ran simulation for a few time steps and checked output. 
