### PR TITLE
update supported python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash -le {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**v0.8.0 - 09/18/23**
+
+ - Remove explicit support for Python 3.7 and 3.8
+
 **v0.7.0 - 09/18/23**
 
  - Add SQ-LNS intervention

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Once you have all three installed, you should open up your normal shell
 You'll then make an environment, clone this repository, then install
 all necessary requirements as follows::
 
-  :~$ conda create --name=vivarium_gates_nutrition_optimization_child python=3.8
+  :~$ conda create --name=vivarium_gates_nutrition_optimization_child python=3.10
   ...conda will download python and base dependencies...
   :~$ conda activate vivarium_gates_nutrition_optimization_child
   (vivarium_gates_nutrition_optimization_child) :~$ git clone https://github.com/ihmeuw/vivarium_gates_nutrition_optimization_child.git


### PR DESCRIPTION
PyTables more or less deprecated Python 3.8 in their most recent release, and it's causing our builds to fail. We determined that it is probably best to just follow suit and drop 3.8 from our CI.