### PR TITLE
LBWSG PAF risk effect

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -5,7 +5,10 @@ from vivarium_gates_nutrition_optimization_child.components.causes import (
 from vivarium_gates_nutrition_optimization_child.components.fertility import (
     FertilityLineList,
 )
-from vivarium_gates_nutrition_optimization_child.components.lbwsg import LBWSGLineList
+from vivarium_gates_nutrition_optimization_child.components.lbwsg import (
+    LBWSGLineList,
+    LBWSGPAFCalculationRiskEffect,
+)
 from vivarium_gates_nutrition_optimization_child.components.maternal_characteristics import (
     AdditiveRiskEffect,
     BEPEffectOnBirthweight,

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -12,6 +12,7 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
+from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.time import get_time_stamp
 from vivarium.framework.values import Pipeline
@@ -20,6 +21,7 @@ from vivarium_public_health.risks.data_transformations import (
 )
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     LBWSGRisk,
+    LBWSGRiskEffect,
 )
 
 
@@ -104,3 +106,10 @@ class LBWSGLineList(LBWSGRisk):
 
     def get_birth_exposure(self, axis: str, index: pd.Index) -> pd.Series:
         return self.new_births.loc[index, axis]
+
+
+class LBWSGPAFCalculationRiskEffect(LBWSGRiskEffect):
+    """Risk effect component for calculating PAFs for LBWSG."""
+
+    def get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
+        return builder.lookup.build_table(0)


### PR DESCRIPTION
## LBWSG PAF risk effect

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-4687](https://jira.ihme.washington.edu/browse/MIC-4687)

### Changes and notes
Add risk effect component for calculating PAFs which doesn't read PAF data and can be used to access simulant relative risk values.

### Verification and Testing
Added component with diarrhea EMR to model spec (after removing original LBWSG risk effect) and accessed relative risk values within another component.