### PR TITLE
mms effect on gestational age bugfix

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -281,6 +281,7 @@ class MMSEffectOnGestationalAge(AdditiveRiskEffect):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
+        super().setup(builder)
         self.ifa_on_gestational_age = builder.components.get_component(
             f"additive_risk_effect.risk_factor.iron_folic_acid_supplementation.{self.target}"
         )


### PR DESCRIPTION
## mms effect on gestational age bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4769](https://jira.ihme.washington.edu/browse/MIC-4769)

### Changes and notes
Add super setup to MMS effect on gestational age.

### Verification and Testing
Compared gestational age exposures in mms scenario to old exposures and verified that shift was occurring. 