### PR TITLE
Bugfix/wasting index columns

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -491,11 +491,20 @@ def load_sam_exposure(builder: Builder, cause: str) -> pd.DataFrame:
 
 # Sub-loader functions
 def load_child_wasting_exposures(builder: Builder) -> pd.DataFrame:
-    exposures = (
-        builder.data.load(WASTING.EXPOSURE)
-        .set_index(metadata.DEMOGRAPHIC_COLUMNS)
-        .pivot(columns="parameter")
-    )
+    # TODO: fix me once components are updated for artifacts with location
+    # in artifact
+    try:
+        exposures = (
+            builder.data.load(WASTING.EXPOSURE)
+            .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
+            .pivot(columns="parameter")
+        )
+    except KeyError:
+        exposures = (
+            builder.data.load(WASTING.EXPOSURE)
+            .set_index(metadata.DEMOGRAPHIC_COLUMNS)
+            .pivot(columns="parameter")
+        )
 
     exposures.columns = exposures.columns.droplevel(0)
     return exposures

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -493,7 +493,7 @@ def load_sam_exposure(builder: Builder, cause: str) -> pd.DataFrame:
 def load_child_wasting_exposures(builder: Builder) -> pd.DataFrame:
     exposures = (
         builder.data.load(WASTING.EXPOSURE)
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
+        .set_index(metadata.DEMOGRAPHIC_COLUMNS)
         .pivot(columns="parameter")
     )
 


### PR DESCRIPTION
## Bugfix/wasting index columns

### Fixes bug that made wasting component not reverse compatible with new subnational artifact code.
- *Category*: Bugfix
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-adds try except block to use correct index column depending on artifact version a user is using.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

