### PR TITLE
Mic-5104/Update exposure to only use wasting exposure if in the artifact

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -64,8 +64,8 @@ configuration:
     input_data:
         input_draw_number: 457
         # Artifact can also be defined at runtime using -i flag
-        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization_child/artifacts/subnational/ethiopia.hdf'
-        fertility_input_data_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization/results/model12.0/ethiopia/2024_04_08_10_17_27/child_data'
+        artifact_path: '/home/albrja/scratch//artifacts/copy_subnational_ethiopia.hdf'
+        fertility_input_data_path: '/home/albrja/scratch/data'
     interpolation:
         order: 0
         extrapolate: True
@@ -79,8 +79,8 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2029
-            month: 12
+            year: 2025
+            month: 1
             day: 31
         step_size: 4 # Days
     population:


### PR DESCRIPTION
## Mic-5104/Update usage of child wasting exosure

### Updates wasting model to only load child wasting exposure if it is in the artifact.
- *Category*: Refactor
- *JIRA issue*: [MIC-5104](https://jira.ihme.washington.edu/browse/MIC-5104)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
-updates child wasting model to only load child wasting exposure data if it is in the artifact otherwise it will be 0
-Note: there is no functionality change in the actual ChildWasting model, this is to hopefully be more clear that we do not seem to be using the child wasting exposure data

### Verification and Testing
Successfully ran simulation

