### PR TITLE
Use new name for exposure column name staticmethod

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -81,7 +81,7 @@ class LBWSGLineList(LBWSGRisk):
     # noinspection PyAttributeOutsideInit
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         if pop_data.creation_time < self.start_time:
-            columns = [self.exposure_column_name(axis) for axis in self.AXES] + [
+            columns = [self.get_exposure_column_name(axis) for axis in self.AXES] + [
                 self.raw_gestational_age_exposure_column_name,
                 self.birth_weight_status_column_name,
             ]
@@ -129,7 +129,7 @@ class LBWSGPAFCalculationExposure(LBWSGRisk):
 
     @property
     def columns_created(self) -> List[str]:
-        return [self.exposure_column_name(axis) for axis in self.AXES] + [
+        return [self.get_exposure_column_name(axis) for axis in self.AXES] + [
             "lbwsg_category",
             "age_bin",
         ]
@@ -175,7 +175,7 @@ class LBWSGPAFCalculationExposure(LBWSGRisk):
         self.population_view.update(pop[["age_bin", "lbwsg_category"]])
 
         birth_exposures = {
-            self.exposure_column_name(axis): self.birth_exposures[
+            self.get_exposure_column_name(axis): self.birth_exposures[
                 self.birth_exposure_pipeline_name(axis)
             ](pop_data.index)
             for axis in self.AXES


### PR DESCRIPTION
## Overwrite newly-named `get_exposure_column_name` method

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> bugfix
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-5296)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
There was a name collision between this `exposure_column_name` staticmethod
and the base Risk's attr. This renamed the staticmethod in VPH
and this follows suit.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Ran a few timesteps
