### PR TITLE
Sbachmei/bugfix/fix risk effects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,9 @@ if __name__ == "__main__":
     install_requirements = [
         "vivarium_build_utils>2.0.3,<3.0.0",
         "gbd_mapping>=4.0.0",
+        "vivarium>=4.0.0, <5.0.0",
         # TODO: UPDATE TO REAL PINS!
-        # "vivarium>=4.0.0, <5.0.0",
         # "vivarium_public_health>=5.0.0, <6.0.0",
-        "vivarium @ git+https://github.com/ihmeuw/vivarium.git@release_candidate/v4.0.0",
         "vivarium_public_health @ git+https://github.com/ihmeuw/vivarium_public_health.git@release-candidate/v5.0.0",
         "click",
         "jinja2",

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -148,6 +148,10 @@ class AdditiveRiskEffect(RiskEffect):
         self._exposure_distribution_type = "ordered_polytomous"
         return self.build_lookup_table(builder, "relative_risk", 1)
 
+    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        """Return constant RR of 1.0; this component uses excess_shift instead."""
+        return lambda index: pd.Series(1.0, index=index)
+
     def build_paf_lookup_table(self, builder: Builder) -> LookupTable:
         return self.build_lookup_table(builder, "paf", 0)
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/risk.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/risk.py
@@ -1,4 +1,5 @@
 import itertools
+from collections.abc import Callable
 from typing import Any, Dict
 
 import pandas as pd
@@ -192,29 +193,37 @@ class CGFRiskEffect(RiskEffect):
     def get_distribution_type(self, builder: Builder) -> str:
         return self._exposure_distribution_type
 
+    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        """Compute combined relative risk from all sub-risk lookup tables."""
+
+        def generate_relative_risk(index: pd.Index) -> pd.Series:
+            exposures = self.population_view.get(
+                index, list(self.sub_exposure_names.values())
+            )
+            combined_rr = pd.Series(1.0, index=index)
+            if index.empty:
+                return combined_rr
+
+            for risk in self.cgf_models:
+                index_columns = ["index", risk.name]
+                rr = self.sub_risk_rr_tables[risk](index)
+                exposure = exposures[self.sub_exposure_names[risk]].reset_index()
+                exposure.columns = index_columns
+                exposure = exposure.set_index(index_columns)
+
+                relative_risk = rr.stack().reset_index()
+                relative_risk.columns = index_columns + ["value"]
+                relative_risk = relative_risk.set_index(index_columns)
+
+                effect = relative_risk.loc[exposure.index, "value"].droplevel(risk.name)
+                combined_rr *= effect
+            return combined_rr
+
+        return generate_relative_risk
+
     def register_relative_risk_pipeline(self, builder):
         builder.value.register_attribute_producer(
             self.relative_risk_name,
             source=self._relative_risk_source,
             required_resources=list(self.sub_exposure_names.values()),
         )
-
-    def adjust_target(self, index: pd.Index, target: pd.Series) -> pd.Series:
-        exposures = self.population_view.get(index, list(self.sub_exposure_names.values()))
-        if index.empty:
-            return target
-
-        for risk in self.cgf_models:
-            index_columns = ["index", risk.name]
-            rr = self.sub_risk_rr_tables[risk](index)
-            exposure = exposures[self.sub_exposure_names[risk]].reset_index()
-            exposure.columns = index_columns
-            exposure = exposure.set_index(index_columns)
-
-            relative_risk = rr.stack().reset_index()
-            relative_risk.columns = index_columns + ["value"]
-            relative_risk = relative_risk.set_index(index_columns)
-
-            effect = relative_risk.loc[exposure.index, "value"].droplevel(risk.name)
-            target *= effect
-        return target


### PR DESCRIPTION
## Fix risk effect bugs

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Problem
In VPH v5, RiskEffect.setup() assigns `self.relative_risk_table = self.build_rr_lookup_table(builder)` and the parent's `get_relative_risk_source()` creates a closure referencing `self.relative_risk_table`. The RR pipeline is now registered as an attribute_producer, meaning it is eagerly evaluated whenever `get_population()` is called. Two subclasses override `build_rr_lookup_table()` in ways that are incompatible with this new contract:

`CGFRiskEffect.build_rr_lookup_table()` returns None (it populates per-sub-risk tables instead). The parent's closure calls `self.relative_risk_table(index)`, raising "TypeError: 'NoneType' object is not callable".

`AdditiveRiskEffect.build_rr_lookup_table()` returns a scalar lookup table (pd.Series but sets `_exposure_distribution_type = "ordered_polytomous"`. The parent's closure takes the categorical branch and calls `rr.stack() on the Series, raising "AttributeError: 'Series' object has no attribute 'stack'".

In old VPH, these bugs were latent because the RR pipeline was a lazy value_producer that was never directly called — `CGFRiskEffect` bypassed it via an `adjust_target()` override, and `AdditiveRiskEffect` uses additive excess shifts rather than multiplicative RR.

Fix
`CGFRiskEffect`: Override `get_relative_risk_source()` to compute the combined RR by iterating over the sub-risk lookup tables, matching each simulant's exposure category to its RR, and multiplying the per-sub-risk effects together. This is the same computation that previously lived in `adjust_target()`. With the RR pipeline now producing correct values, the `adjust_target()` override is removed — the parent's version reads the combined RR from the pipeline, eliminating duplicated logic.

`AdditiveRiskEffect`: Override `get_relative_risk_source()` to return a constant [pd.Series(1.0, ...). This component has no multiplicative RR — it applies its effect through the `effect_name` pipeline and its own `adjust_target()` override, which adds the excess shift to birth exposure.


### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
- Confirmed sims run w/o runtime errors
- Confirmed we can now call the relative risk that Ali was unble to w/o the error

