### PR TITLE
Updating LBWSG Exposure to 2021

### DIFF
--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -1318,9 +1318,9 @@ def load_sam_treatment_rr(
     #       = (sam_tx_efficacy / sam_tx_duration) / (sam_tx_efficacy_tmrel / sam_tx_duration)
     #       = sam_tx_efficacy / sam_tx_efficacy_tmrel
     rr_sam_treated_remission = sam_tx_efficacy / sam_tx_efficacy_tmrel
-    rr_sam_treated_remission[
-        "affected_entity"
-    ] = "severe_acute_malnutrition_to_mild_child_wasting"
+    rr_sam_treated_remission["affected_entity"] = (
+        "severe_acute_malnutrition_to_mild_child_wasting"
+    )
 
     # rr_r2 = r2 / r2_tmrel
     #       = (1 - sam_tx_efficacy) * (r2_ux) / (1 - sam_tx_efficacy_tmrel) * (r2_ux)
@@ -1329,12 +1329,12 @@ def load_sam_treatment_rr(
 
     better_mam_rows = rr_sam_untreated_remission.copy()
     worse_mam_rows = rr_sam_untreated_remission.copy()
-    better_mam_rows[
-        "affected_entity"
-    ] = "severe_acute_malnutrition_to_better_moderate_acute_malnutrition"
-    worse_mam_rows[
-        "affected_entity"
-    ] = "severe_acute_malnutrition_to_worse_moderate_acute_malnutrition"
+    better_mam_rows["affected_entity"] = (
+        "severe_acute_malnutrition_to_better_moderate_acute_malnutrition"
+    )
+    worse_mam_rows["affected_entity"] = (
+        "severe_acute_malnutrition_to_worse_moderate_acute_malnutrition"
+    )
     rr_sam_untreated_remission = pd.concat([better_mam_rows, worse_mam_rows])
 
     rr = pd.concat([rr_sam_treated_remission, rr_sam_untreated_remission])
@@ -1367,9 +1367,9 @@ def load_mam_treatment_rr(
 
     mam_ux_duration = data_values.WASTING.MAM_UX_RECOVERY_TIME_OVER_6MO
     mam_tx_duration = pd.Series(index=index)
-    mam_tx_duration[
-        index.get_level_values("age_start") < 0.5
-    ] = data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
+    mam_tx_duration[index.get_level_values("age_start") < 0.5] = (
+        data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
+    )
     mam_tx_duration[0.5 <= index.get_level_values("age_start")] = get_random_variable_draws(
         mam_tx_duration[0.5 <= index.get_level_values("age_start")].index,
         *data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO,
@@ -1390,12 +1390,12 @@ def load_mam_treatment_rr(
 
     better_mam_rows = rr.copy()
     worse_mam_rows = rr.copy()
-    better_mam_rows[
-        "affected_entity"
-    ] = "better_moderate_acute_malnutrition_to_mild_child_wasting"
-    worse_mam_rows[
-        "affected_entity"
-    ] = "worse_moderate_acute_malnutrition_to_mild_child_wasting"
+    better_mam_rows["affected_entity"] = (
+        "better_moderate_acute_malnutrition_to_mild_child_wasting"
+    )
+    worse_mam_rows["affected_entity"] = (
+        "worse_moderate_acute_malnutrition_to_mild_child_wasting"
+    )
     rr = pd.concat([better_mam_rows, worse_mam_rows])
 
     rr["affected_measure"] = "transition_rate"
@@ -1414,9 +1414,12 @@ def load_mam_treatment_rr(
 def load_lbwsg_exposure(
     key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
 ) -> pd.DataFrame:
+    key = EntityKey(key)
+    entity = utilities.get_entity(key)
 
     # Get exposure for all age groups except birth age group
-    exposure = load_standard_data(key, location)
+    exposure = interface.get_measure(entity, key.measure, location, 2021)
+    exposure = exposure.query("year_start == 2021")
     # Sometimes there are data values on the order of 10e-300 that cause
     # floating point headaches, so clip everything to reasonable values
     exposure = exposure.clip(lower=vi_globals.MINIMUM_EXPOSURE_VALUE)
@@ -1429,6 +1432,7 @@ def load_lbwsg_exposure(
         .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ["parameter"])
         .sort_index()
     )
+    exposure = reshape_to_vivarium_format(exposure, location)
     return exposure
 
 

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -1318,9 +1318,9 @@ def load_sam_treatment_rr(
     #       = (sam_tx_efficacy / sam_tx_duration) / (sam_tx_efficacy_tmrel / sam_tx_duration)
     #       = sam_tx_efficacy / sam_tx_efficacy_tmrel
     rr_sam_treated_remission = sam_tx_efficacy / sam_tx_efficacy_tmrel
-    rr_sam_treated_remission["affected_entity"] = (
-        "severe_acute_malnutrition_to_mild_child_wasting"
-    )
+    rr_sam_treated_remission[
+        "affected_entity"
+    ] = "severe_acute_malnutrition_to_mild_child_wasting"
 
     # rr_r2 = r2 / r2_tmrel
     #       = (1 - sam_tx_efficacy) * (r2_ux) / (1 - sam_tx_efficacy_tmrel) * (r2_ux)
@@ -1329,12 +1329,12 @@ def load_sam_treatment_rr(
 
     better_mam_rows = rr_sam_untreated_remission.copy()
     worse_mam_rows = rr_sam_untreated_remission.copy()
-    better_mam_rows["affected_entity"] = (
-        "severe_acute_malnutrition_to_better_moderate_acute_malnutrition"
-    )
-    worse_mam_rows["affected_entity"] = (
-        "severe_acute_malnutrition_to_worse_moderate_acute_malnutrition"
-    )
+    better_mam_rows[
+        "affected_entity"
+    ] = "severe_acute_malnutrition_to_better_moderate_acute_malnutrition"
+    worse_mam_rows[
+        "affected_entity"
+    ] = "severe_acute_malnutrition_to_worse_moderate_acute_malnutrition"
     rr_sam_untreated_remission = pd.concat([better_mam_rows, worse_mam_rows])
 
     rr = pd.concat([rr_sam_treated_remission, rr_sam_untreated_remission])
@@ -1367,9 +1367,9 @@ def load_mam_treatment_rr(
 
     mam_ux_duration = data_values.WASTING.MAM_UX_RECOVERY_TIME_OVER_6MO
     mam_tx_duration = pd.Series(index=index)
-    mam_tx_duration[index.get_level_values("age_start") < 0.5] = (
-        data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
-    )
+    mam_tx_duration[
+        index.get_level_values("age_start") < 0.5
+    ] = data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
     mam_tx_duration[0.5 <= index.get_level_values("age_start")] = get_random_variable_draws(
         mam_tx_duration[0.5 <= index.get_level_values("age_start")].index,
         *data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO,
@@ -1390,12 +1390,12 @@ def load_mam_treatment_rr(
 
     better_mam_rows = rr.copy()
     worse_mam_rows = rr.copy()
-    better_mam_rows["affected_entity"] = (
-        "better_moderate_acute_malnutrition_to_mild_child_wasting"
-    )
-    worse_mam_rows["affected_entity"] = (
-        "worse_moderate_acute_malnutrition_to_mild_child_wasting"
-    )
+    better_mam_rows[
+        "affected_entity"
+    ] = "better_moderate_acute_malnutrition_to_mild_child_wasting"
+    worse_mam_rows[
+        "affected_entity"
+    ] = "worse_moderate_acute_malnutrition_to_mild_child_wasting"
     rr = pd.concat([better_mam_rows, worse_mam_rows])
 
     rr["affected_measure"] = "transition_rate"


### PR DESCRIPTION
## Title: Updating LBWSG Exposure to 2021

### Description
Changing LBWSG to be 2021 instead. We continue to use LBWSG 2021 data for the birth exposure in the pregnancy model, and this just makes this data key in line with others. This was likely an oversight in the original implementation. See related slack discussion for reference here: https://ihme.slack.com/archives/C02944X688L/p1779902983112089

- *Category*: bugfix 

### Changes and notes
I used the code we had in the child model when we needed to pull 2019 GBD data for some causes. 

### Verification and Testing
To test this, I ran a new artifact and then examined the data to ensure it seemed similar to the old version and looked as expected. 
