### PR TITLE
Migrate to monorepo and VPH 5.1 on GBD 2023

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,14 @@ endif
 # Set the package name as the last part of this file's parent directory path
 PACKAGE_NAME = $(notdir $(CURDIR))
 
+# TODO: remove after monorepo migration
+# Explicit PyPI distribution name. Without this, vivarium_build_utils' base.mk
+# falls back to PACKAGE_NAME for `--config-settings-package` (vbu>=3.3.0), which
+# in a Jenkins PR workspace is the dir basename (e.g. "..._PR-207-head@2") and is
+# rejected by uv as an invalid package name. Remove once pyproject.toml declares
+# a [project] table with `name = "vivarium_gates_nutrition_optimization_child"`.
+DIST_NAME := vivarium_gates_nutrition_optimization_child
+
 # Helper function for validating enum arguments
 validate_arg = $(if $(filter-out $(2),$(1)),$(error Error: '$(3)' must be one of: $(2), got '$(1)'))
 

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ ifdef JENKINS_URL
 # 	Files are already in workspace from shared library
 	MAKE_INCLUDES := .
 else
-# 	For local dev, use the installed vivarium_build_utils package if it exists
-# 	First, check if we can import vivarium_build_utils and assign 'yes' or 'no'.
+# 	For local dev, use the installed vivarium.build_utils package if it exists
+# 	First, check if we can import vivarium.build_utils and assign 'yes' or 'no'.
 # 	We do this by importing the package in python and redirecting stderr to the null device.
 # 	If the import is successful (&&), it will print 'yes', otherwise (||) it will print 'no'.
-	VIVARIUM_BUILD_UTILS_AVAILABLE := $(shell python -c "import vivarium_build_utils" 2>/dev/null && echo "yes" || echo "no")
-# 	If vivarium_build_utils is available, get the makefiles path or else set it to empty
+	VIVARIUM_BUILD_UTILS_AVAILABLE := $(shell python -c "import vivarium.build_utils" 2>/dev/null && echo "yes" || echo "no")
+# 	If vivarium.build_utils is available, get the makefiles path or else set it to empty
 	ifeq ($(VIVARIUM_BUILD_UTILS_AVAILABLE),yes)
-		MAKE_INCLUDES := $(shell python -c "from vivarium_build_utils.resources import get_makefiles_path; print(get_makefiles_path())")
+		MAKE_INCLUDES := $(shell python -c "from vivarium.build_utils.resources import get_makefiles_path; print(get_makefiles_path())")
 	else
 		MAKE_INCLUDES :=
 	endif
@@ -18,14 +18,6 @@ endif
 
 # Set the package name as the last part of this file's parent directory path
 PACKAGE_NAME = $(notdir $(CURDIR))
-
-# TODO: remove after monorepo migration
-# Explicit PyPI distribution name. Without this, vivarium_build_utils' base.mk
-# falls back to PACKAGE_NAME for `--config-settings-package` (vbu>=3.3.0), which
-# in a Jenkins PR workspace is the dir basename (e.g. "..._PR-207-head@2") and is
-# rejected by uv as an invalid package name. Remove once pyproject.toml declares
-# a [project] table with `name = "vivarium_gates_nutrition_optimization_child"`.
-DIST_NAME := vivarium_gates_nutrition_optimization_child
 
 # Helper function for validating enum arguments
 validate_arg = $(if $(filter-out $(2),$(1)),$(error Error: '$(3)' must be one of: $(2), got '$(1)'))
@@ -100,10 +92,7 @@ build-env: # Create a new environment with installed packages
 	
 	conda create -n $(name) python=$(py) --yes
 # 	Bootstrap vivarium_build_utils into the new environment
-# 	Pin to <3.0.0 to match this repo's cluster_tools 2.x line
-#	NOTE: cluster_tools 2.x transitively requires vbu<3.0.0, so installing a v3.x or v4.x
-#		wheel here would just be downgraded by `make install` and break the in-flight build.
-	conda run -n $(name) pip install "vivarium_build_utils<3.0.0"
+	conda run -n $(name) pip install "vivarium_build_utils>=4.0.0,<5.0.0"
 #	Install packages based on type
 	@if [ "$(type)" = "simulation" ]; then \
 		conda run -n $(name) make install ENV_REQS=dev; \

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,12 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium_build_utils>=3.0.2,<3.3.3",
         "gbd_mapping>=4.0.0, <5.0.0",
-        "vivarium>=4.1.0",
-        "vivarium_public_health>=5.1.5",
+        "vivarium-engine>=5.3.0,<6.0.0",
+        "vivarium-public-health>=6.3.1,<7.0.0",
+        "vivarium-config-tree",
+        "vivarium-risk-distributions",
+        "vivarium_build_utils>=4.0.0,<5.0.0",
         "click",
         "jinja2",
         "loguru",
@@ -56,7 +58,6 @@ if __name__ == "__main__":
         "pyyaml",
         "scipy",
         "tables",
-        "layered_config_tree<5.0.0",
     ]
 
     # use "pip install -e .[dev]" to install required components + extra components
@@ -64,12 +65,13 @@ if __name__ == "__main__":
         "vivarium_inputs>=5.0.0, <7.0.0",
         "vivarium_gbd_access>=4.0.0, <5.0.0",
     ]
-    cluster_requirements = ["vivarium_cluster_tools>=2.0.0, <3.0.0"]
+    cluster_requirements = ["vivarium_cluster_tools>=4.0.0, <5.0.0"]
 
     test_requirements = [
         "pytest",
         "pytest-cov",
         "pytest-mock",
+        "pytest-xdist",
     ]
     lint_requirements = [
         "black==22.3.0",

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium_build_utils>2.0.3,<3.0.0",
-        "gbd_mapping>=4.0.0,<6.0.0",
-        "vivarium>=4.0.0, <4.1.0",
-        "vivarium_public_health>=5.0.0, <5.1.0",
+        "vivarium_build_utils>=3.0.2,<3.3.3",
+        "gbd_mapping>=4.0.0, <5.0.0",
+        "vivarium>=4.1.0",
+        "vivarium_public_health>=5.1.5",
         "click",
         "jinja2",
         "loguru",
@@ -60,7 +60,10 @@ if __name__ == "__main__":
     ]
 
     # use "pip install -e .[dev]" to install required components + extra components
-    data_requirements = ["vivarium_inputs[data]>=5.0.0"]
+    data_requirements = [
+        "vivarium_inputs>=5.0.0, <7.0.0",
+        "vivarium_gbd_access>=4.0.0, <5.0.0",
+    ]
     cluster_requirements = ["vivarium_cluster_tools>=2.0.0, <3.0.0"]
 
     test_requirements = [

--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -13,6 +13,7 @@ from vivarium_gates_nutrition_optimization_child.components.lbwsg import (
     LBWSGPAFCalculationExposure,
     LBWSGPAFCalculationRiskEffect,
     LBWSGPAFObserver,
+    SubnationalLBWSGRiskEffect,
 )
 from vivarium_gates_nutrition_optimization_child.components.maternal_characteristics import (
     BEPEffectOnBirthweight,

--- a/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/__init__.py
@@ -41,4 +41,5 @@ from vivarium_gates_nutrition_optimization_child.components.treatment import (
 from vivarium_gates_nutrition_optimization_child.components.wasting import (
     ChildWasting,
     WastingTreatment,
+    WastingTreatmentEffect,
 )

--- a/src/vivarium_gates_nutrition_optimization_child/components/calibration_paf.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/calibration_paf.py
@@ -1,0 +1,71 @@
+"""
+================================
+Calibration PAF subnational fill
+================================
+
+Reindex a RiskEffect's calibration-constant (PAF) table onto a shared grid.
+
+When two RiskEffects target the same rate -- here CGF and LBWSG on the
+diarrheal/LRI excess mortality rate -- vph hands both PAF tables to the
+``raw_union`` combiner, which aligns them by index. CGF is subnational- and
+post-neonatal-specific; LBWSG is national and neonatal-only. Left unaligned,
+the union produces NaN and setup fails. Reindexing both onto
+``subnational x sex x under-5 age bin x year`` with 0-fill lets them combine;
+because the two risks are age-disjoint, the fill changes no values.
+"""
+
+import pandas as pd
+from vivarium.engine.framework.engine import Builder
+
+from vivarium_gates_nutrition_optimization_child.constants import data_keys, metadata
+
+_DIMENSION_COLUMNS = [
+    "subnational",
+    "sex",
+    "age_start",
+    "age_end",
+    "year_start",
+    "year_end",
+]
+
+
+def fill_subnational_paf_rows(builder: Builder, paf: pd.DataFrame) -> pd.DataFrame:
+    """Reindex a PAF table onto the shared subnational x sex x under-5 age x year grid.
+
+    Missing rows are 0-filled. When ``paf`` lacks a subnational level its values
+    are broadcast across every subnational. Non-DataFrame inputs (e.g. scalars)
+    are returned unchanged.
+    """
+    if not isinstance(paf, pd.DataFrame):
+        return paf
+
+    value_columns = [c for c in paf.columns if c not in _DIMENSION_COLUMNS]
+
+    # Pull the canonical age bins from the artifact so boundaries match the
+    # tables' own float representation exactly (avoids near-equal mismatches).
+    age_bins = builder.data.load(data_keys.POPULATION.AGE_BINS)
+    under_5 = (
+        age_bins[age_bins["age_end"] <= 5.0][["age_start", "age_end"]]
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+
+    location = builder.data.load(data_keys.POPULATION.LOCATION)
+    if isinstance(location, (list, tuple, pd.Series, pd.Index)):
+        location = list(location)[0]
+    subnationals = metadata.SUBNATIONAL_LOCATION_DICT[location]
+
+    sexes = sorted(paf["sex"].unique())
+    years = paf[["year_start", "year_end"]].drop_duplicates()
+
+    grid = (
+        pd.DataFrame({"subnational": subnationals})
+        .merge(pd.DataFrame({"sex": sexes}), how="cross")
+        .merge(under_5, how="cross")
+        .merge(years, how="cross")
+    )
+
+    merge_keys = [c for c in _DIMENSION_COLUMNS if c in paf.columns]
+    filled = grid.merge(paf, on=merge_keys, how="left")
+    filled[value_columns] = filled[value_columns].fillna(0.0)
+    return filled[_DIMENSION_COLUMNS + value_columns]

--- a/src/vivarium_gates_nutrition_optimization_child/components/causes.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/causes.py
@@ -2,13 +2,13 @@
 Component to include birth prevalence in SIS model.
 """
 
-from vivarium.framework.state_machine import State
-from vivarium_public_health.disease import DiseaseModel, DiseaseState
-from vivarium_public_health.disease import (
+from vivarium.engine.framework.state_machine import State
+from vivarium.public_health.disease import DiseaseModel, DiseaseState
+from vivarium.public_health.disease import (
     RiskAttributableDisease as RiskAttributableDisease_,
 )
-from vivarium_public_health.disease import SusceptibleState
-from vivarium_public_health.disease.transition import TransitionString
+from vivarium.public_health.disease import SusceptibleState
+from vivarium.public_health.disease.transition import TransitionString
 
 
 def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:

--- a/src/vivarium_gates_nutrition_optimization_child/components/distribution.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/distribution.py
@@ -4,19 +4,18 @@ import numpy as np
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
 from vivarium.framework.engine import Builder
-from vivarium_public_health.risks.distributions import (
-    MissingDataError,
-    PolytomousDistribution,
-)
+from vivarium_public_health.causal_factor.distributions import PolytomousDistribution
 from vivarium_public_health.utilities import EntityString
 
 
 class CGFPolytomousDistribution(PolytomousDistribution):
+    @property
+    def name(self) -> str:
+        return f"cgf_polytomous_distribution.{self.causal_factor}"
+
     def __init__(self, risk: EntityString, exposure_data: pd.DataFrame):
         super().__init__(risk, "ordered_polytomous", exposure_data)
-        # Overwrite the risk propensity name since all sub-distributions share the
-        # parent ChildUnderweight's propensity column
-        self.risk_propensity = "child_underweight.propensity"
+        self.causal_factor_propensity = "child_underweight.propensity"
 
     def get_configuration(self, builder: "Builder") -> Optional[LayeredConfigTree]:
         pass

--- a/src/vivarium_gates_nutrition_optimization_child/components/distribution.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/distribution.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from layered_config_tree import LayeredConfigTree
-from vivarium.framework.engine import Builder
-from vivarium_public_health.causal_factor.distributions import PolytomousDistribution
-from vivarium_public_health.utilities import EntityString
+from vivarium.config_tree import ConfigTree
+from vivarium.engine.framework.engine import Builder
+from vivarium.public_health.causal_factor.distributions import PolytomousDistribution
+from vivarium.public_health.utilities import EntityString
 
 
 class CGFPolytomousDistribution(PolytomousDistribution):
@@ -17,7 +17,7 @@ class CGFPolytomousDistribution(PolytomousDistribution):
         super().__init__(risk, "ordered_polytomous", exposure_data)
         self.causal_factor_propensity = "child_underweight.propensity"
 
-    def get_configuration(self, builder: "Builder") -> Optional[LayeredConfigTree]:
+    def get_configuration(self, builder: "Builder") -> Optional[ConfigTree]:
         pass
 
     def register_exposure_ppf_pipeline(self, builder: Builder) -> None:

--- a/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/fertility.py
@@ -11,10 +11,10 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium_public_health import utilities
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.public_health import utilities
 
 PREGNANCY_DURATION = pd.Timedelta(days=9 * utilities.DAYS_PER_MONTH)
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -14,21 +14,24 @@ from typing import Dict
 
 import numpy as np
 import pandas as pd
-from vivarium.component import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
-from vivarium.framework.population import SimulantData
-from vivarium.framework.time import get_time_stamp
-from vivarium.framework.values import Pipeline
-from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
-from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
+from vivarium.engine.component import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.time import get_time_stamp
+from vivarium.engine.framework.values import Pipeline
+from vivarium.public_health.causal_factor.utilities import get_exposure_post_processor
+from vivarium.public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     AXES,
     LBWSGRisk,
     LBWSGRiskEffect,
     Risk,
 )
-from vivarium_public_health.utilities import TargetString
+from vivarium.public_health.utilities import TargetString
 
+from vivarium_gates_nutrition_optimization_child.components.calibration_paf import (
+    fill_subnational_paf_rows,
+)
 from vivarium_gates_nutrition_optimization_child.constants import data_keys
 
 
@@ -122,6 +125,20 @@ class LBWSGPAFCalculationRiskEffect(LBWSGRiskEffect):
 
     def get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
         return 0, []
+
+
+class SubnationalLBWSGRiskEffect(LBWSGRiskEffect):
+    """LBWSGRiskEffect whose calibration PAF is filled across subnational rows.
+
+    Use in place of ``LBWSGRiskEffect`` where LBWSG shares a target rate with
+    the subnational, post-neonatal CGF effect (diarrheal/LRI excess mortality)
+    so vph's ``raw_union`` can align the two PAFs.
+    """
+
+    def get_calibration_constant_data(self, builder: Builder) -> pd.DataFrame:
+        """Broadcast the national, neonatal-only LBWSG PAF onto the shared grid."""
+        paf = super().get_calibration_constant_data(builder)
+        return fill_subnational_paf_rows(builder, paf)
 
 
 class LBWSGPAFCalculationExposure(LBWSGRisk):

--- a/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/lbwsg.py
@@ -10,7 +10,7 @@ simulants who are initialized from line list data.
 
 import itertools
 import math
-from typing import Dict, List, Optional
+from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -20,9 +20,7 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 from vivarium.framework.values import Pipeline
-from vivarium_public_health.risks.data_transformations import (
-    get_exposure_post_processor,
-)
+from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import (
     AXES,
     LBWSGRisk,
@@ -44,7 +42,6 @@ class LBWSGLineList(LBWSGRisk):
         self.raw_gestational_age_exposure_column_name = "raw_gestational_age_exposure"
         self.birth_weight_status_column_name = "birth_weight_status"
 
-    # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         Risk.setup(self, builder)
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -13,7 +13,8 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import SimulantData
 from vivarium.framework.time import get_time_stamp
 from vivarium.framework.values import Pipeline
-from vivarium_public_health.risks import RiskEffect
+from vivarium_public_health.causal_factor.utilities import pivot_categorical
+from vivarium_public_health.utilities import EntityString, TargetString
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, data_values
 from vivarium_gates_nutrition_optimization_child.constants.data_keys import (
@@ -122,9 +123,17 @@ class MaternalCharacteristics(Component):
         return exposure
 
 
-class LBWSGAdditiveRiskEffect(RiskEffect):
+class LBWSGAdditiveRiskEffect(Component):
+    @property
+    def name(self) -> str:
+        return f"risk_effect.{self.risk.name}_on_{self.target}"
+
     def __init__(self, risk: str, target: str):
-        super().__init__(risk, target)
+        super().__init__()
+        self.risk = EntityString(risk)
+        self.target = TargetString(target)
+
+        self.exposure_name = f"{self.risk.name}.exposure"
         self.effect_name = f"{self.risk.name}_on_{self.target.name}.effect"
 
     #################
@@ -133,7 +142,6 @@ class LBWSGAdditiveRiskEffect(RiskEffect):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.excess_shift_table = self.get_excess_shift_lookup_table(builder)
         self.risk_specific_shift_table = self.get_risk_specific_shift_lookup_table(builder)
         self.excess_shift = self.get_excess_shift(builder)
@@ -143,17 +151,11 @@ class LBWSGAdditiveRiskEffect(RiskEffect):
             source=self.get_effect,
             required_resources=[self.exposure_name],
         )
-
-    def build_rr_lookup_table(self, builder: Builder) -> LookupTable:
-        self._exposure_distribution_type = "ordered_polytomous"
-        return self.build_lookup_table(builder, "relative_risk", 1)
-
-    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
-        """Return constant RR of 1.0; this component uses excess_shift instead."""
-        return lambda index: pd.Series(1.0, index=index)
-
-    def build_paf_lookup_table(self, builder: Builder) -> LookupTable:
-        return self.build_lookup_table(builder, "paf", 0)
+        builder.value.register_attribute_modifier(
+            "low_birth_weight_and_short_gestation.birth_exposure",
+            modifier=self.adjust_target,
+            required_resources=[self.effect_name],
+        )
 
     def get_excess_shift_lookup_table(self, builder: Builder) -> LookupTable:
         excess_shift_data = builder.data.load(
@@ -167,18 +169,6 @@ class LBWSGAdditiveRiskEffect(RiskEffect):
         )
         return self.build_lookup_table(builder, "excess_shift", excess_shift_data, value_cols)
 
-    def register_target_modifier(self, builder: Builder) -> None:
-        builder.value.register_attribute_modifier(
-            "low_birth_weight_and_short_gestation.birth_exposure",
-            modifier=self.adjust_target,
-            required_resources=[self.relative_risk_name],
-        )
-
-    def adjust_target(self, index: pd.Index, target: pd.DataFrame) -> pd.Series:
-        effect = self.population_view.get(index, self.effect_name)
-        target[self.target.name] += effect
-        return target
-
     def get_risk_specific_shift_lookup_table(self, builder: Builder) -> LookupTable:
         risk_specific_shift_data = builder.data.load(
             f"{self.risk}.risk_specific_shift",
@@ -189,15 +179,34 @@ class LBWSGAdditiveRiskEffect(RiskEffect):
             builder, "risk_specific_shift", risk_specific_shift_data, "value"
         )
 
-    def register_paf_modifier(self, builder: Builder) -> None:
-        pass
-
     def get_excess_shift(self, builder: Builder) -> Union[LookupTable, Pipeline]:
         return self.excess_shift_table
+
+    def process_categorical_data(
+        self, builder: Builder, data: Union[str, float, pd.DataFrame]
+    ) -> tuple[pd.DataFrame, list[str]]:
+        if not isinstance(data, pd.DataFrame):
+            cat1 = builder.data.load("population.demographic_dimensions")
+            cat1["parameter"] = "cat1"
+            cat1["value"] = data
+            cat2 = cat1.copy()
+            cat2["parameter"] = "cat2"
+            cat2["value"] = 1
+            data = pd.concat([cat1, cat2], ignore_index=True)
+        if "parameter" in data.index.names:
+            data = data.reset_index("parameter")
+        value_cols = list(data["parameter"].unique())
+        data = pivot_categorical(data, "parameter")
+        return data, value_cols
 
     ##################################
     # Pipeline sources and modifiers #
     ##################################
+
+    def adjust_target(self, index: pd.Index, target: pd.DataFrame) -> pd.DataFrame:
+        effect = self.population_view.get(index, self.effect_name)
+        target[self.target.name] += effect
+        return target
 
     def get_effect(self, index: pd.Index) -> pd.Series:
         index_columns = ["index", self.risk.name]

--- a/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/maternal_characteristics.py
@@ -7,14 +7,14 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
-from vivarium.framework.population import SimulantData
-from vivarium.framework.time import get_time_stamp
-from vivarium.framework.values import Pipeline
-from vivarium_public_health.causal_factor.utilities import pivot_categorical
-from vivarium_public_health.utilities import EntityString, TargetString
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.time import get_time_stamp
+from vivarium.engine.framework.values import Pipeline
+from vivarium.public_health.causal_factor.utilities import pivot_categorical
+from vivarium.public_health.utilities import EntityString, TargetString
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, data_values
 from vivarium_gates_nutrition_optimization_child.constants.data_keys import (

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -1,15 +1,15 @@
 from typing import Any, Dict
 
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium_public_health.disease import DiseaseState
-from vivarium_public_health.results import COLUMNS
-from vivarium_public_health.results.disease import DiseaseObserver
-from vivarium_public_health.results.mortality import (
+from vivarium.engine.framework.engine import Builder
+from vivarium.public_health.disease import DiseaseState
+from vivarium.public_health.results import COLUMNS
+from vivarium.public_health.results.disease import DiseaseObserver
+from vivarium.public_health.results.mortality import (
     MortalityObserver as MortalityObserver_,
 )
-from vivarium_public_health.results.simple_cause import SimpleCause
-from vivarium_public_health.results.stratification import (
+from vivarium.public_health.results.simple_cause import SimpleCause
+from vivarium.public_health.results.stratification import (
     ResultsStratifier as ResultsStratifier_,
 )
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/observers.py
@@ -30,25 +30,19 @@ class ResultsStratifier(ResultsStratifier_):
     def get_age_bins(self, builder: Builder) -> pd.DataFrame:
         """Define final age groups for production runs."""
         age_bins = super().get_age_bins(builder)
+        # Alternative coarse bins, kept for reference:
+        # age_start=[0.0, 0.5, 0.833333, 1.5], age_end=[0.5, 0.833333, 1.5, 5],
+        # names=["0_to_6_months", "6_to_10_months", "10_to_18_months", "18_to_59_months"].)
         data_dict = {
-            "age_start": [
-                0.0,
-                0.5,
-                0.833333,
-                1.5,
-            ],  # [0.0, 0.019178, 0.076712, 0.5, 1.0, 2.0],
-            "age_end": [0.5, 0.833333, 1.5, 5],  # [0.019178, 0.076712, 0.5, 1.0, 2.0, 5.0],
+            "age_start": [0.0, 0.019178, 0.076712, 0.5, 1.0, 2.0],
+            "age_end": [0.019178, 0.076712, 0.5, 1.0, 2.0, 5.0],
             "age_group_name": [
-                # "early_neonatal",
-                # "late_neonatal",
-                # "1-5_months",
-                # "6-11_months",
-                # "12_to_23_months",
-                # "2_to_4",
-                "0_to_6_months",
-                "6_to_10_months",
-                "10_to_18_months",
-                "18_to_59_months",
+                "early_neonatal",
+                "late_neonatal",
+                "1-5_months",
+                "6-11_months",
+                "12_to_23_months",
+                "2_to_4",
             ],
         }
 
@@ -58,13 +52,13 @@ class ResultsStratifier(ResultsStratifier_):
         """Register each desired stratification with calls to _setup_stratification"""
         super().register_stratifications(builder)
 
-        # builder.results.register_stratification(
-        #     "wasting_state",
-        #     [category.value for category in data_keys.ChildWastingCategories],
-        #     mapper=self.child_wasting_stratification_mapper,
-        #     is_vectorized=True,
-        #     requires_attributes=["child_wasting.exposure"],
-        # )
+        builder.results.register_stratification(
+            "wasting_state",
+            [category.value for category in data_keys.ChildWastingCategories],
+            mapper=self.child_wasting_stratification_mapper,
+            is_vectorized=True,
+            requires_attributes=["child_wasting.exposure"],
+        )
         # builder.results.register_stratification(
         #     "stunting_state",
         #     [category.value for category in data_keys.CGFCategories],
@@ -140,16 +134,15 @@ class ResultsStratifier(ResultsStratifier_):
     #     }
     #     return pop.squeeze(axis=1).map(mapper)
 
-    # def child_wasting_stratification_mapper(self, pop: pd.DataFrame) -> pd.Series:
-    #     # applicable to stunting and wasting
-    #     mapper = {
-    #         "cat4": data_keys.ChildWastingCategories.UNEXPOSED.value,
-    #         "cat3": data_keys.ChildWastingCategories.MILD.value,
-    #         "cat2.5": data_keys.ChildWastingCategories.BETTER_MODERATE.value,
-    #         "cat2": data_keys.ChildWastingCategories.WORSE_MODERATE.value,
-    #         "cat1": data_keys.ChildWastingCategories.SEVERE.value,
-    #     }
-    #     return pop.squeeze(axis=1).map(mapper)
+    def child_wasting_stratification_mapper(self, pop: pd.DataFrame) -> pd.Series:
+        mapper = {
+            "cat4": data_keys.ChildWastingCategories.UNEXPOSED.value,
+            "cat3": data_keys.ChildWastingCategories.MILD.value,
+            "cat2.5": data_keys.ChildWastingCategories.BETTER_MODERATE.value,
+            "cat2": data_keys.ChildWastingCategories.WORSE_MODERATE.value,
+            "cat1": data_keys.ChildWastingCategories.SEVERE.value,
+        }
+        return pop.squeeze(axis=1).map(mapper)
 
     def map_wasting_treatment(self, pop: pd.DataFrame) -> pd.Series:
         # Both SAM and MAM treatments

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -7,7 +7,7 @@ This module contains a component for creating a base population from line list d
 
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,6 @@ from vivarium_public_health.population.data_transformations import (
 )
 from vivarium_public_health.population.mortality import Mortality
 
-from vivarium_gates_nutrition_optimization_child import utilities as utils
 from vivarium_gates_nutrition_optimization_child.constants import data_keys
 from vivarium_gates_nutrition_optimization_child.constants.paths import (
     SUBNATIONAL_PERCENTAGES,
@@ -124,6 +123,11 @@ class PopulationLineList(BasePopulation):
                 )
             else:
                 new_simulants["subnational"] = self.subnational
+
+        # Coerce the object-dtype time columns (NaT/Timestamp) to datetime64 so
+        # initialize() can cast them to the population's column dtype.
+        for time_column in ["entrance_time", "exit_time"]:
+            new_simulants[time_column] = pd.to_datetime(new_simulants[time_column])
 
         self.population_view.initialize(new_simulants)
 

--- a/src/vivarium_gates_nutrition_optimization_child/components/population.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/population.py
@@ -11,14 +11,14 @@ from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.population import SimulantData
-from vivarium.framework.time import get_time_stamp
-from vivarium_public_health.population.base_population import BasePopulation, Disability
-from vivarium_public_health.population.data_transformations import (
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.time import get_time_stamp
+from vivarium.public_health.population.base_population import BasePopulation, Disability
+from vivarium.public_health.population.data_transformations import (
     assign_demographic_proportions,
 )
-from vivarium_public_health.population.mortality import Mortality
+from vivarium.public_health.population.mortality import Mortality
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys
 from vivarium_gates_nutrition_optimization_child.constants.paths import (

--- a/src/vivarium_gates_nutrition_optimization_child/components/risk.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/risk.py
@@ -3,14 +3,17 @@ from collections.abc import Callable
 from typing import Any, Dict
 
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.values import Pipeline
-from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
-from vivarium_public_health.risks import Risk, RiskEffect
-from vivarium_public_health.utilities import EntityString
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.values import Pipeline
+from vivarium.public_health.causal_factor.utilities import get_exposure_post_processor
+from vivarium.public_health.risks import Risk, RiskEffect
+from vivarium.public_health.utilities import EntityString
 
 from vivarium_gates_nutrition_optimization_child.components import (
     CGFPolytomousDistribution,
+)
+from vivarium_gates_nutrition_optimization_child.components.calibration_paf import (
+    fill_subnational_paf_rows,
 )
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, data_values
 
@@ -170,6 +173,16 @@ class CGFRiskEffect(RiskEffect):
         self.sub_exposure_names = {risk: f"{risk.name}.exposure" for risk in self.cgf_models}
         self.sub_risk_rr_tables = {}
         super().setup(builder)
+
+    def get_calibration_constant_data(self, builder: Builder) -> pd.DataFrame:
+        """Fill subnational rows of the CGF PAF so it aligns with LBWSG.
+
+        Adds 0-valued neonatal age bins to the subnational, post-neonatal CGF
+        PAF so vph's ``raw_union`` can combine it with the neonatal-only LBWSG
+        PAF on shared targets (diarrheal/LRI excess mortality).
+        """
+        paf = super().get_calibration_constant_data(builder)
+        return fill_subnational_paf_rows(builder, paf)
 
     def build_rr_lookup_table(self, builder) -> None:
         for risk in self.cgf_models:

--- a/src/vivarium_gates_nutrition_optimization_child/components/risk.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/risk.py
@@ -5,10 +5,8 @@ from typing import Any, Dict
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.values import Pipeline
+from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
 from vivarium_public_health.risks import Risk, RiskEffect
-from vivarium_public_health.risks.data_transformations import (
-    get_exposure_post_processor,
-)
 from vivarium_public_health.utilities import EntityString
 
 from vivarium_gates_nutrition_optimization_child.components import (
@@ -76,14 +74,9 @@ class ChildUnderweight(Risk):
             wasting_cat = wasting_cat.replace(".", "")
             key = f"risk_factor.stunting_{stunting_cat}_wasting_{wasting_cat}_underweight"
 
-            distributions[key] = CGFPolytomousDistribution(
-                EntityString(key), distribution_data
-            )
-        for dist in distributions.values():
-            # HACK / FIXME [MIC-6756]
-            self._components._manager._current_component = dist
-            dist.setup_component(builder)
-            self._components._manager._current_component = self
+            distribution = CGFPolytomousDistribution(EntityString(key), distribution_data)
+            distribution.setup_component(builder)
+            distributions[key] = distribution
         return distributions
 
     ##################################
@@ -167,8 +160,6 @@ class CGFRiskEffect(RiskEffect):
                 data_keys.STUNTING.name,
             ]
         ]
-        # This is to access to the distribution type before setup
-        self._exposure_distribution_type = "ordered_polytomous"
         # Override relative risk name to include the measure to avoid collisions
         # between instances targeting the same entity with different measures
         self.relative_risk_name = (
@@ -191,7 +182,7 @@ class CGFRiskEffect(RiskEffect):
             )
 
     def get_distribution_type(self, builder: Builder) -> str:
-        return self._exposure_distribution_type
+        return "ordered_polytomous"
 
     def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
         """Compute combined relative risk from all sub-risk lookup tables."""

--- a/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
@@ -29,7 +29,6 @@ class SQLNSTreatment(Component):
             ["location", "targeted_ghi"]
         ]
 
-    # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(f"initial_{self.name}_propensity")
         self.scenario = scenarios.INTERVENTION_SCENARIOS[
@@ -158,29 +157,26 @@ class SQLNSTreatment(Component):
 
         return coverage
 
-    def apply_tmrel_to_mild_wasting_treatment(
-        self, index: pd.Index, target: pd.Series
-    ) -> pd.Series:
-        covered = self.population_view.get(index, self.coverage_name) == "covered"
-        target[covered] = target[covered] * self.tmrel_to_mild_wasting_risk_ratio_table(index)
+    def apply_tmrel_to_mild_wasting_treatment(self, index: pd.Index) -> pd.Series:
+        coverage = self.population_view.get(index, self.coverage_name)
+        covered = coverage[coverage == "covered"].index
+        treatment_effect = pd.Series(1, index=index)
+        treatment_effect[covered] = self.tmrel_to_mild_wasting_risk_ratio_table(covered)
+        return treatment_effect
 
-        return target
+    def apply_mild_to_mam_wasting_treatment(self, index: pd.Index) -> pd.Series:
+        coverage = self.population_view.get(index, self.coverage_name)
+        covered = coverage[coverage == "covered"].index
+        treatment_effect = pd.Series(1, index=index)
+        treatment_effect[covered] = self.mild_to_mam_wasting_risk_ratio_table(covered)
+        return treatment_effect
 
-    def apply_mild_to_mam_wasting_treatment(
-        self, index: pd.Index, target: pd.Series
-    ) -> pd.Series:
-        covered = self.population_view.get(index, self.coverage_name) == "covered"
-        target[covered] = target[covered] * self.mild_to_mam_wasting_risk_ratio_table(index)
-
-        return target
-
-    def apply_mam_to_sam_wasting_treatment(
-        self, index: pd.Index, target: pd.Series
-    ) -> pd.Series:
-        covered = self.population_view.get(index, self.coverage_name) == "covered"
-        target[covered] = target[covered] * self.mam_to_sam_wasting_risk_ratio_table(index)
-
-        return target
+    def apply_mam_to_sam_wasting_treatment(self, index: pd.Index) -> pd.Series:
+        coverage = self.population_view.get(index, self.coverage_name)
+        covered = coverage[coverage == "covered"].index
+        treatment_effect = pd.Series(1, index=index)
+        treatment_effect[covered] = self.mam_to_sam_wasting_risk_ratio_table(covered)
+        return treatment_effect
 
     def apply_stunting_treatment(self, index: pd.Index, target: pd.DataFrame) -> pd.DataFrame:
         cat1_decrease = target.loc[:, "cat1"] * (

--- a/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/treatment.py
@@ -3,9 +3,9 @@
 from typing import Dict, List, Optional
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
 
 from vivarium_gates_nutrition_optimization_child.constants import (
     data_keys,

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -6,11 +6,9 @@ from vivarium.framework.artifact.artifact import ArtifactException
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
+from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
 from vivarium_public_health.disease import DiseaseModel, DiseaseState, SusceptibleState
-from vivarium_public_health.risks import Risk
-from vivarium_public_health.risks.data_transformations import (
-    get_exposure_post_processor,
-)
+from vivarium_public_health.treatment import Intervention, InterventionEffect
 from vivarium_public_health.utilities import EntityString
 
 from vivarium_gates_nutrition_optimization_child.constants import (
@@ -22,11 +20,19 @@ from vivarium_gates_nutrition_optimization_child.constants import (
 )
 
 
-class WastingTreatment(Risk):
+class WastingTreatment(Intervention):
     @property
     def configuration_defaults(self) -> Dict[str, Any]:
-        base_risk_config = super().configuration_defaults
-        return {self.name: base_risk_config[self.name]}
+        config = super().configuration_defaults
+        # The treatment exposure and distribution data live under the legacy
+        # ``risk_factor.*`` artifact keys, so source them from there rather than
+        # the default ``intervention.*`` keys this component would otherwise use.
+        treatment_name = self.intervention.name
+        config[self.name]["data_sources"][
+            "exposure"
+        ] = f"risk_factor.{treatment_name}.exposure"
+        config[self.name]["distribution_type"] = f"risk_factor.{treatment_name}.distribution"
+        return config
 
     @property
     def time_step_prepare_priority(self) -> int:
@@ -46,7 +52,7 @@ class WastingTreatment(Risk):
     ##########################
 
     def _get_treated_state(self) -> str:
-        return self.risk.name.split("_treatment")[0]
+        return self.intervention.name.split("_treatment")[0]
 
     #################
     # Setup methods #
@@ -116,7 +122,7 @@ class WastingTreatment(Risk):
         if isinstance(index, pd.RangeIndex):
             index = pd.Index(index.to_list())
 
-        is_mam_component = self.risk.name == "moderate_acute_malnutrition_treatment"
+        is_mam_component = self.intervention.name == "moderate_acute_malnutrition_treatment"
         coverage_to_exposure_map = {"none": "cat1", "full": "cat2"}
 
         if is_mam_component:
@@ -169,6 +175,27 @@ class WastingTreatment(Risk):
                 return pd.Series(exposure, index=index)
 
 
+class WastingTreatmentEffect(InterventionEffect):
+    """Effect of a wasting treatment intervention on a wasting transition rate.
+
+    The treatment's relative-risk and PAF data live under the legacy
+    ``risk_factor.*`` artifact keys, so override the default ``intervention.*``
+    data sources to point at them.
+    """
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        config = super().configuration_defaults
+        treatment_name = self.intervention.name
+        config[self.name]["data_sources"][
+            "relative_risk"
+        ] = f"risk_factor.{treatment_name}.relative_risk"
+        config[self.name]["data_sources"][
+            "population_attributable_fraction"
+        ] = f"risk_factor.{treatment_name}.population_attributable_fraction"
+        return config
+
+
 class ChildWastingModel(DiseaseModel):
     @property
     def configuration_defaults(self) -> Dict[str, Any]:
@@ -219,6 +246,7 @@ class ChildWastingModel(DiseaseModel):
             ],
             required_resources=[
                 self.randomness,
+                "birth_weight_status",
                 *self.initialization_weights_pipelines,
             ],
         )

--- a/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
+++ b/src/vivarium_gates_nutrition_optimization_child/components/wasting.py
@@ -2,14 +2,14 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
-from vivarium.framework.artifact.artifact import ArtifactException
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
-from vivarium_public_health.causal_factor.utilities import get_exposure_post_processor
-from vivarium_public_health.disease import DiseaseModel, DiseaseState, SusceptibleState
-from vivarium_public_health.treatment import Intervention, InterventionEffect
-from vivarium_public_health.utilities import EntityString
+from vivarium.artifact import ArtifactException
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
+from vivarium.public_health.causal_factor.utilities import get_exposure_post_processor
+from vivarium.public_health.disease import DiseaseModel, DiseaseState, SusceptibleState
+from vivarium.public_health.treatment import Intervention, InterventionEffect
+from vivarium.public_health.utilities import EntityString
 
 from vivarium_gates_nutrition_optimization_child.constants import (
     data_keys,

--- a/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
+++ b/src/vivarium_gates_nutrition_optimization_child/constants/data_keys.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import NamedTuple
 
-from vivarium_public_health.utilities import TargetString
+from vivarium.public_health.utilities import TargetString
 
 #############
 # Data Keys #

--- a/src/vivarium_gates_nutrition_optimization_child/data/builder.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/builder.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pandas as pd
 from loguru import logger
-from vivarium.framework.artifact import Artifact, EntityKey
+from vivarium.artifact import Artifact, EntityKey
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys
 from vivarium_gates_nutrition_optimization_child.data import loader

--- a/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         metrics:
             - ResultsStratifier()
     vivarium_gates_nutrition_optimization_child:

--- a/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_calculator.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_calculator.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 from vivarium.artifact import Artifact
-from vivarium.engine import InteractiveContext
 from vivarium.cluster_tools.utilities import mkdir
+from vivarium.engine import InteractiveContext
 from vivarium_gbd_access import gbd
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, metadata

--- a/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_calculator.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_calculator.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from loguru import logger
-from vivarium import Artifact, InteractiveContext
-from vivarium_cluster_tools.utilities import mkdir
+from vivarium.artifact import Artifact
+from vivarium.engine import InteractiveContext
+from vivarium.cluster_tools.utilities import mkdir
 from vivarium_gbd_access import gbd
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, metadata

--- a/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_south_asia.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_south_asia.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         population:
             - BasePopulation()
         risks:

--- a/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_sub-saharan_africa.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/data/lbwsg_paf_sub-saharan_africa.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         population:
             - BasePopulation()
         risks:

--- a/src/vivarium_gates_nutrition_optimization_child/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/loader.py
@@ -20,7 +20,8 @@ import numpy as np
 import pandas as pd
 from gbd_mapping import Cause, RiskFactor, sequelae
 from scipy.interpolate import RectBivariateSpline, griddata
-from vivarium.framework.artifact import EntityKey
+from vivarium.artifact import EntityKey
+from vivarium.public_health.utilities import TargetString
 from vivarium_gbd_access import constants as gbd_constants
 from vivarium_gbd_access import gbd
 from vivarium_inputs import extract
@@ -30,7 +31,6 @@ from vivarium_inputs import utilities as vi_utils
 from vivarium_inputs import utility_data
 from vivarium_inputs.globals import DEMOGRAPHIC_COLUMNS, DRAW_COLUMNS
 from vivarium_inputs.mapping_extension import AlternativeRiskFactor
-from vivarium_public_health.utilities import TargetString
 
 from vivarium_gates_nutrition_optimization_child.constants import (
     data_keys,

--- a/src/vivarium_gates_nutrition_optimization_child/data/utilities.py
+++ b/src/vivarium_gates_nutrition_optimization_child/data/utilities.py
@@ -13,7 +13,7 @@ from gbd_mapping import (
     covariates,
     risk_factors,
 )
-from vivarium.framework.artifact import EntityKey
+from vivarium.artifact import EntityKey
 from vivarium_gbd_access import constants as gbd_constants
 from vivarium_gbd_access import utilities as vi_utils
 

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/ethiopia_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/ethiopia_mean_model_spec.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
@@ -7,8 +7,6 @@ components:
         risks:
             - Risk('risk_factor.child_stunting')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -43,6 +41,8 @@ components:
             - CGFRiskEffect('cause.measles.excess_mortality_rate')
             - CGFRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGAdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - LBWSGAdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/ethiopia_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/ethiopia_mean_model_spec.yaml
@@ -6,16 +6,9 @@ components:
             - SIS('malaria')
         risks:
             - Risk('risk_factor.child_stunting')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -32,8 +25,13 @@ components:
             - LBWSGLineList()
             - ChildWasting()
             - ChildWastingObserver()
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.severe_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.moderate_acute_malnutrition_treatment')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - SQLNSTreatment()
             - MaternalCharacteristics()
             - ChildUnderweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_mean_model_spec.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
@@ -7,8 +7,6 @@ components:
         risks:
             - Risk('risk_factor.child_stunting')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -43,6 +41,8 @@ components:
             - CGFRiskEffect('cause.measles.excess_mortality_rate')
             - CGFRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGAdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - LBWSGAdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_mean_model_spec.yaml
@@ -6,16 +6,9 @@ components:
             - SIS('malaria')
         risks:
             - Risk('risk_factor.child_stunting')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -32,8 +25,13 @@ components:
             - LBWSGLineList()
             - ChildWasting()
             - ChildWastingObserver()
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.severe_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.moderate_acute_malnutrition_treatment')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - SQLNSTreatment()
             - MaternalCharacteristics()
             - ChildUnderweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_model_spec.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
@@ -7,8 +7,6 @@ components:
         risks:
             - Risk('risk_factor.child_stunting')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -43,6 +41,8 @@ components:
             - CGFRiskEffect('cause.measles.excess_mortality_rate')
             - CGFRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGAdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - LBWSGAdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()
@@ -58,17 +58,17 @@ components:
 
 configuration:
     input_data:
-        input_draw_number: 216
+        input_draw_number: 457
         # Artifact can also be defined at runtime using -i flag
         artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization_child/artifacts/model_15.0/nigeria.hdf"
-        fertility_input_data_path: "/home/rmudambi/scratch/0000.parquet"
+        fertility_input_data_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization/results/model12.0/nigeria/2024_04_05_12_18_41/child_data"
     interpolation:
         order: 0
         extrapolate: True
     randomness:
         map_size: 1_000_000
         key_columns: ["entrance_time", "age", "maternal_id"]
-        random_seed: 2284
+        random_seed: 4344
     time:
         start:
             year: 2025

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nigeria_model_spec.yaml
@@ -6,16 +6,9 @@ components:
             - SIS('malaria')
         risks:
             - Risk('risk_factor.child_stunting')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -32,8 +25,13 @@ components:
             - LBWSGLineList()
             - ChildWasting()
             - ChildWastingObserver()
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.severe_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.moderate_acute_malnutrition_treatment')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - SQLNSTreatment()
             - MaternalCharacteristics()
             - ChildUnderweight()
@@ -60,17 +58,17 @@ components:
 
 configuration:
     input_data:
-        input_draw_number: 457
+        input_draw_number: 216
         # Artifact can also be defined at runtime using -i flag
-        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization_child/artifacts/model_15.0/nigeria.hdf'
-        fertility_input_data_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization/results/model12.0/nigeria/2024_04_05_12_18_41/child_data'
+        artifact_path: "/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization_child/artifacts/model_15.0/nigeria.hdf"
+        fertility_input_data_path: "/home/rmudambi/scratch/0000.parquet"
     interpolation:
         order: 0
         extrapolate: True
     randomness:
         map_size: 1_000_000
-        key_columns: ['entrance_time', 'age', 'maternal_id']
-        random_seed: 4344
+        key_columns: ["entrance_time", "age", "maternal_id"]
+        random_seed: 2284
     time:
         start:
             year: 2025
@@ -88,11 +86,11 @@ configuration:
         untracking_age: 5
 
     intervention:
-        child_scenario: 'baseline'
-        maternal_scenario: 'baseline'
-        sqlns_effect_size: 'standard'
-        subnational: 'All'
-    
+        child_scenario: "baseline"
+        maternal_scenario: "baseline"
+        sqlns_effect_size: "standard"
+        subnational: "All"
+
     mortality_line_list:
         unmodeled_causes:
             - "upper_respiratory_infections"
@@ -109,28 +107,28 @@ configuration:
             - "neonatal_diarrheal_diseases"
 
     risk_attributable_disease.moderate_protein_energy_malnutrition:
-        threshold: ['cat2','cat2.5']
+        threshold: ["cat2", "cat2.5"]
         mortality: True
         recoverable: True
     risk_attributable_disease.severe_protein_energy_malnutrition:
-        threshold: ['cat1']
+        threshold: ["cat1"]
         mortality: True
         recoverable: True
 
     stratification:
         default:
-            - 'age_group'
-            - 'sex'
+            - "age_group"
+            - "sex"
         child_wasting:
-            include: ['sam_treatment', 'mam_treatment']
+            include: ["sam_treatment", "mam_treatment"]
         child_stunting:
-            include: ['sqlns_coverage']
+            include: ["sqlns_coverage"]
         excluded_categories:
             cause_of_death:
-                - 'stillborn'
+                - "stillborn"
             disability:
-                - 'all_causes'
-                - 'mild_child_wasting'
-                - 'better_moderate_acute_malnutrition'
-                - 'worse_moderate_acute_malnutrition'
-                - 'severe_acute_malnutrition'
+                - "all_causes"
+                - "mild_child_wasting"
+                - "better_moderate_acute_malnutrition"
+                - "worse_moderate_acute_malnutrition"
+                - "severe_acute_malnutrition"

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
@@ -7,8 +7,6 @@ components:
         risks:
             - Risk('risk_factor.child_stunting')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -43,6 +41,8 @@ components:
             - CGFRiskEffect('cause.measles.excess_mortality_rate')
             - CGFRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGAdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - LBWSGAdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/nutrition_optimization_child.yaml
@@ -6,16 +6,9 @@ components:
             - SIS('malaria')
         risks:
             - Risk('risk_factor.child_stunting')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -32,8 +25,13 @@ components:
             - LBWSGLineList()
             - ChildWasting()
             - ChildWastingObserver()
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.severe_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.moderate_acute_malnutrition_treatment')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - SQLNSTreatment()
             - MaternalCharacteristics()
             - ChildUnderweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/pakistan_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/pakistan_mean_model_spec.yaml
@@ -1,5 +1,5 @@
 components:
-    vivarium_public_health:
+    vivarium.public_health:
         disease:
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
@@ -7,8 +7,6 @@ components:
         risks:
             - Risk('risk_factor.child_stunting')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -43,6 +41,8 @@ components:
             - CGFRiskEffect('cause.measles.excess_mortality_rate')
             - CGFRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - CGFRiskEffect('cause.malaria.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - SubnationalLBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGAdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - LBWSGAdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.birth_weight.birth_exposure')
             - BEPEffectOnBirthweight()

--- a/src/vivarium_gates_nutrition_optimization_child/model_specifications/pakistan_mean_model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization_child/model_specifications/pakistan_mean_model_spec.yaml
@@ -6,16 +6,9 @@ components:
             - SIS('malaria')
         risks:
             - Risk('risk_factor.child_stunting')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
         results:
             - DiseaseObserver('diarrheal_diseases')
             - DiseaseObserver('measles')
@@ -32,8 +25,13 @@ components:
             - LBWSGLineList()
             - ChildWasting()
             - ChildWastingObserver()
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.severe_acute_malnutrition_treatment')
+            - WastingTreatment('intervention.moderate_acute_malnutrition_treatment')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_better_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_worse_moderate_acute_malnutrition.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.better_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - WastingTreatmentEffect('intervention.moderate_acute_malnutrition_treatment', 'risk_factor.worse_moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - SQLNSTreatment()
             - MaternalCharacteristics()
             - ChildUnderweight()

--- a/src/vivarium_gates_nutrition_optimization_child/tools/cli.py
+++ b/src/vivarium_gates_nutrition_optimization_child/tools/cli.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import click
 from loguru import logger
-from vivarium.framework.utilities import handle_exceptions
+from vivarium.engine.framework.utilities import handle_exceptions
 
 from vivarium_gates_nutrition_optimization_child.constants import metadata, paths
 from vivarium_gates_nutrition_optimization_child.tools import (

--- a/src/vivarium_gates_nutrition_optimization_child/tools/make_artifacts.py
+++ b/src/vivarium_gates_nutrition_optimization_child/tools/make_artifacts.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Tuple, Union
 
 import click
-import vivarium_cluster_tools as vct
+import vivarium.cluster_tools as vct
 from loguru import logger
 
 from vivarium_gates_nutrition_optimization_child.constants import data_keys, metadata
@@ -111,7 +111,7 @@ def build_artifacts(
         How noisy the logger should be.
     """
 
-    import vivarium_cluster_tools as vct
+    import vivarium.cluster_tools as vct
 
     output_dir = Path(output_dir)
     vct.mkdir(output_dir, parents=True, exists_ok=True)
@@ -149,7 +149,10 @@ def build_all_artifacts(output_dir: Path, verbose: int, fetch_subnationals: bool
         called by the :func:`build_artifacts` function located in the same
         module.
     """
-    from vivarium_cluster_tools.utilities import get_drmaa
+    # NOTE: get_drmaa was removed from vivarium-cluster-tools in the 4.x monorepo
+    # line. The subnational parallel-build (DRMAA) path below needs a follow-up to
+    # the new API. Out of scope here (artifact building); left as-is intentionally.
+    from vivarium.cluster_tools.utilities import get_drmaa
 
     drmaa = get_drmaa()
 

--- a/src/vivarium_gates_nutrition_optimization_child/utilities.py
+++ b/src/vivarium_gates_nutrition_optimization_child/utilities.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from loguru import logger
 from scipy import stats
-from vivarium.framework.randomness import get_hash
+from vivarium.engine.framework.randomness import get_hash
 
 from vivarium_gates_nutrition_optimization_child.constants import metadata
 

--- a/src/vivarium_gates_nutrition_optimization_child/utilities.py
+++ b/src/vivarium_gates_nutrition_optimization_child/utilities.py
@@ -7,7 +7,6 @@ import pandas as pd
 from loguru import logger
 from scipy import stats
 from vivarium.framework.randomness import get_hash
-from vivarium_public_health.risks.data_transformations import pivot_categorical
 
 from vivarium_gates_nutrition_optimization_child.constants import metadata
 


### PR DESCRIPTION
## Title: Migrate to monorepo and VPH 5.1 on GBD 2023

### Description
- *Category*: refactor
- *JIRA issue*: [MIC-7247](https://jira.ihme.washington.edu/browse/MIC-7247)
- *Research reference*: n/a (library/packaging migration; no model-logic change)

### Changes and notes
Brings the monorepo + VPH 5.1 (vph5.1 → vph6) migration onto `main`'s GBD 2023
base, so we have a clean monorepo/VPH child model on GBD 2023. Structured as two
commits:

1. **Get child model working with VPH 5.1 (engine / public-health split)** — the
   VPH 5.1 behavioral updates, including the LBWSG-EMR-on-diarrheal/LRI restore
   that vph5.1 had dropped.
2. **Migrate to vivarium monorepo namespaces and vivarium-suite packaging** —
   adopt the monorepo import namespaces (`vivarium.engine` / `vivarium.public_health`
   / `vivarium.artifact` / `vivarium.cluster_tools` / `vivarium.config_tree`),
   depend on the released vivarium-suite packages (vivarium-engine 5.x,
   vivarium-public-health 6.x, vivarium-build-utils 4.x, vivarium-cluster-tools
   4.x) with the monorepo Makefile, and the CGF/LBWSG calibration-PAF
   harmonization so vph6 `raw_union` can combine them.

How it was built: the feature delta from the validated GBD-2021 monorepo/VPH
branch (`hjafari/feature/mic-7247_child_2021_vph_5.1_monorepo`) was applied onto
`main`. 26 of 29 changed files are byte-identical to that validated branch;
`data/loader.py` and `data/utilities.py` retain `main`'s GBD 2023 data logic with
only the namespace-import lines layered on (no 2023 logic touched).

Beyond the validated branch, two monorepo-completion fixes: `vivarium_cluster_tools`
→ `vivarium.cluster_tools` (the vct 4.x import name) and `LayeredConfigTree` →
`ConfigTree` (the non-deprecated config-tree class).

Notes for reviewers:
- `tools/make_artifacts.py` still calls `get_drmaa`, which was removed from
  vivarium-cluster-tools 4.x. This is a pre-existing gap (present on the validated
  branch too), only affects the subnational DRMAA artifact-build path (a lazy
  import), and is flagged in a code comment. Getting artifacts to build is out of
  scope for this PR.

### Verification and Testing
- **Tree correctness gate:** all clean-applying files are byte-identical to the
  validated GBD-2021 branch (which was proven bit-identical to sbachmei's vph5.0
  run); `GBD_EXTRACT_YEAR = 2023` and the 2023 data logic in `loader.py`/`utilities.py`
  are preserved (they differ from `main` only by namespace-import lines).
- **Import validation:** every runtime component module imports cleanly in the
  monorepo sim env (0 failures); `vivarium.cluster_tools`, `vivarium.config_tree`
  / `ConfigTree`, and `vivarium.risk_distributions` all resolve against the
  installed monorepo packages; no `LayeredConfigTree` deprecation and no leftover
  pre-monorepo namespaces.
- A full `simulate run` was **not** performed: the spec's fertility-births input
  is a placeholder path, and artifact building is out of scope here.
